### PR TITLE
Add protocol YAML scripting engine with decorator-based command regis…

### DIFF
--- a/configs/protocol.sample.yaml
+++ b/configs/protocol.sample.yaml
@@ -1,0 +1,11 @@
+# Sample protocol: move pipette between two wells.
+# Load with: load_protocol_from_yaml("configs/protocol.sample.yaml")
+# Execute with: protocol.run(ProtocolContext(board=board, deck=deck))
+
+protocol:
+  - move:
+      instrument: pipette
+      position: plate_1.A1
+  - move:
+      instrument: pipette
+      position: plate_1.C9

--- a/src/protocol_engine/__init__.py
+++ b/src/protocol_engine/__init__.py
@@ -1,3 +1,18 @@
 from src.protocol_engine.board import Board
+from src.protocol_engine.errors import ProtocolExecutionError, ProtocolLoaderError
+from src.protocol_engine.loader import load_protocol_from_yaml, load_protocol_from_yaml_safe
+from src.protocol_engine.protocol import Protocol, ProtocolContext, ProtocolStep
+from src.protocol_engine.registry import CommandRegistry, protocol_command
 
-__all__ = ["Board"]
+__all__ = [
+    "Board",
+    "CommandRegistry",
+    "Protocol",
+    "ProtocolContext",
+    "ProtocolExecutionError",
+    "ProtocolLoaderError",
+    "ProtocolStep",
+    "load_protocol_from_yaml",
+    "load_protocol_from_yaml_safe",
+    "protocol_command",
+]

--- a/src/protocol_engine/commands/__init__.py
+++ b/src/protocol_engine/commands/__init__.py
@@ -1,0 +1,9 @@
+"""Protocol commands package.
+
+Importing this package triggers all @protocol_command decorators,
+populating the CommandRegistry.
+"""
+
+from . import move  # noqa: F401 -- side-effect import for registration
+
+__all__ = ["move"]

--- a/src/protocol_engine/commands/move.py
+++ b/src/protocol_engine/commands/move.py
@@ -1,0 +1,27 @@
+"""Protocol command: move."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..registry import protocol_command
+
+if TYPE_CHECKING:
+    from ..protocol import ProtocolContext
+
+
+@protocol_command("move")
+def move(context: ProtocolContext, instrument: str, position: str) -> None:
+    """Move *instrument* to *position* on the deck.
+
+    Direct 1:1 mapping to ``Board.move(instrument, position)``.
+
+    Args:
+        context:    Runtime context (board, deck, logger).
+        instrument: Name of the instrument registered on the board (e.g. "pipette").
+        position:   Deck target string resolved via ``Deck.resolve()``
+                    (e.g. "plate_1.A1", "vial_1").
+    """
+    coord = context.deck.resolve(position)
+    context.logger.info("move: %s -> %s (%s)", instrument, position, coord)
+    context.board.move(instrument, coord)

--- a/src/protocol_engine/errors.py
+++ b/src/protocol_engine/errors.py
@@ -1,0 +1,9 @@
+"""Protocol engine exception types."""
+
+
+class ProtocolLoaderError(Exception):
+    """Human-friendly protocol loader error intended for CLI output."""
+
+
+class ProtocolExecutionError(Exception):
+    """Error raised during protocol step execution."""

--- a/src/protocol_engine/loader.py
+++ b/src/protocol_engine/loader.py
@@ -1,0 +1,106 @@
+"""Load protocol YAML into an executable Protocol."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+import yaml
+from pydantic import ValidationError
+
+# Side-effect import: triggers all @protocol_command decorators so that
+# the CommandRegistry is populated before any YAML is validated.
+from . import commands as _commands  # noqa: F401
+
+from .errors import ProtocolLoaderError
+from .protocol import Protocol, ProtocolStep
+from .registry import CommandRegistry
+from .yaml_schema import ProtocolYamlSchema
+
+
+def _format_loader_exception(path: Path, error: Exception) -> str:
+    """Return a concise, actionable error message with fix guidance.
+
+    Mirrors ``src/deck/loader.py::_format_loader_exception``.
+    """
+    detail = str(error)
+
+    if isinstance(error, ValidationError):
+        first_error = error.errors()[0] if error.errors() else {}
+        detail = first_error.get("msg", detail)
+        error_type = first_error.get("type", "")
+        location = ".".join(str(part) for part in first_error.get("loc", []))
+
+        if "Unknown protocol command" in detail:
+            registry = CommandRegistry.instance()
+            guidance = (
+                "Use a registered command. "
+                f"Available: {', '.join(registry.command_names)}."
+            )
+        elif error_type == "missing" or "Field required" in detail:
+            guidance = "Add the missing required argument shown in the error location."
+        elif "extra_forbidden" in error_type or "Extra inputs are not permitted" in detail:
+            guidance = "Remove unknown arguments; only registered parameters are allowed."
+        elif "exactly one command" in detail:
+            guidance = "Each list item under 'protocol:' must contain exactly one command."
+        else:
+            guidance = "Review the protocol YAML against the command schemas."
+
+        prefix = f" at `{location}`" if location else ""
+        return f"Protocol YAML error{prefix}: {detail}\nHow to fix: {guidance}"
+
+    if isinstance(error, yaml.YAMLError):
+        return (
+            f"Protocol YAML parse error in `{path}`.\n"
+            "How to fix: Check YAML indentation, colons, and list/dict structure."
+        )
+
+    return (
+        f"Protocol loader error in `{path}`: {detail}\n"
+        "How to fix: Verify the file path and protocol YAML contents."
+    )
+
+
+def _compile_steps(schema: ProtocolYamlSchema) -> List[ProtocolStep]:
+    """Convert validated schema steps into executable ProtocolStep objects."""
+    registry = CommandRegistry.instance()
+    steps: List[ProtocolStep] = []
+    for i, step_schema in enumerate(schema.protocol):
+        registered = registry.get(step_schema.command)
+        validated_args = registered.schema.model_validate(step_schema.args)
+        steps.append(
+            ProtocolStep(
+                index=i,
+                command_name=step_schema.command,
+                handler=registered.handler,
+                args=validated_args.model_dump(),
+            )
+        )
+    return steps
+
+
+def load_protocol_from_yaml(path: str | Path) -> Protocol:
+    """Load a protocol YAML file and return an executable Protocol."""
+    path = Path(path)
+    with path.open() as f:
+        raw = yaml.safe_load(f)
+    if raw is None:
+        raw = {}
+    schema = ProtocolYamlSchema.model_validate(raw)
+    steps = _compile_steps(schema)
+    return Protocol(steps=steps, source_path=path)
+
+
+def load_protocol_from_yaml_safe(path: str | Path) -> Protocol:
+    """Load protocol YAML with user-friendly exception formatting.
+
+    Raises:
+        ProtocolLoaderError: concise, actionable message intended for CLI output.
+    """
+    resolved_path = Path(path)
+    try:
+        return load_protocol_from_yaml(resolved_path)
+    except Exception as exc:
+        raise ProtocolLoaderError(
+            _format_loader_exception(resolved_path, exc)
+        ) from exc

--- a/src/protocol_engine/protocol.py
+++ b/src/protocol_engine/protocol.py
@@ -1,0 +1,107 @@
+"""Protocol: executable sequence of validated protocol steps."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, List
+
+from src.deck.deck import Deck
+
+from .board import Board
+
+
+@dataclass
+class ProtocolContext:
+    """Runtime context injected into every command handler.
+
+    Provides access to the Board (gantry + instruments) and the Deck
+    (labware target resolution).
+    """
+
+    board: Board
+    deck: Deck
+    logger: logging.Logger = field(
+        default_factory=lambda: logging.getLogger("protocol"),
+    )
+
+
+@dataclass
+class ProtocolStep:
+    """One compiled, executable protocol step."""
+
+    index: int
+    command_name: str
+    handler: Callable
+    args: Dict[str, Any]
+
+    def execute(self, context: ProtocolContext) -> Any:
+        """Run this step, passing *context* and unpacked *args* to the handler."""
+        context.logger.info(
+            "Step %d: %s(%s)",
+            self.index,
+            self.command_name,
+            ", ".join(f"{k}={v!r}" for k, v in self.args.items()),
+        )
+        return self.handler(context, **self.args)
+
+
+class Protocol:
+    """An executable protocol: a validated, ordered list of steps.
+
+    Usage from YAML::
+
+        protocol = load_protocol_from_yaml("my_protocol.yaml")
+        context = ProtocolContext(board=board, deck=deck)
+        protocol.run(context)
+
+    Usage from pure Python (no YAML)::
+
+        from src.protocol_engine.commands.move import move
+
+        steps = [
+            ProtocolStep(
+                index=0,
+                command_name="move",
+                handler=move,
+                args={"instrument": "pipette", "position": "plate_1.A1"},
+            ),
+        ]
+        protocol = Protocol(steps=steps)
+        protocol.run(context)
+    """
+
+    def __init__(
+        self,
+        steps: List[ProtocolStep],
+        source_path: Path | None = None,
+    ) -> None:
+        self._steps = list(steps)
+        self.source_path = source_path
+        self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
+
+    @property
+    def steps(self) -> List[ProtocolStep]:
+        return list(self._steps)
+
+    def __len__(self) -> int:
+        return len(self._steps)
+
+    def run(self, context: ProtocolContext) -> List[Any]:
+        """Execute all steps sequentially. Returns list of step results."""
+        self.logger.info(
+            "Running protocol (%d steps)%s",
+            len(self._steps),
+            f" from {self.source_path}" if self.source_path else "",
+        )
+        results: List[Any] = []
+        for step in self._steps:
+            result = step.execute(context)
+            results.append(result)
+        self.logger.info("Protocol complete.")
+        return results
+
+    def __repr__(self) -> str:
+        cmds = ", ".join(s.command_name for s in self._steps)
+        return f"Protocol([{cmds}])"

--- a/src/protocol_engine/registry.py
+++ b/src/protocol_engine/registry.py
@@ -1,0 +1,120 @@
+"""Command registry: @protocol_command decorator and CommandRegistry singleton."""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any, Callable, Dict, Type
+
+from pydantic import BaseModel, ConfigDict, create_model
+
+
+class RegisteredCommand:
+    """A registered command: its name, handler callable, and Pydantic schema."""
+
+    __slots__ = ("name", "handler", "schema")
+
+    def __init__(self, name: str, handler: Callable, schema: Type[BaseModel]) -> None:
+        self.name = name
+        self.handler = handler
+        self.schema = schema
+
+
+class CommandRegistry:
+    """Singleton registry mapping YAML command names to handlers + schemas."""
+
+    _instance: CommandRegistry | None = None
+
+    def __init__(self) -> None:
+        self._commands: Dict[str, RegisteredCommand] = {}
+
+    @classmethod
+    def instance(cls) -> CommandRegistry:
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    @classmethod
+    def reset(cls) -> None:
+        """Reset the singleton for test isolation."""
+        cls._instance = None
+
+    def register(self, name: str, handler: Callable, schema: Type[BaseModel]) -> None:
+        if name in self._commands:
+            raise ValueError(f"Protocol command '{name}' is already registered.")
+        self._commands[name] = RegisteredCommand(
+            name=name, handler=handler, schema=schema,
+        )
+
+    def get(self, name: str) -> RegisteredCommand:
+        if name not in self._commands:
+            available = ", ".join(sorted(self._commands.keys()))
+            raise KeyError(
+                f"Unknown protocol command '{name}'. "
+                f"Available commands: {available}"
+            )
+        return self._commands[name]
+
+    @property
+    def command_names(self) -> list[str]:
+        return sorted(self._commands.keys())
+
+
+def _build_schema_from_signature(
+    name: str, func: Callable,
+) -> Type[BaseModel]:
+    """Introspect a function's signature and build a strict Pydantic model.
+
+    Skips ``self`` and ``context`` parameters (context is injected at runtime).
+    All remaining parameters become required schema fields unless they have
+    default values in the function signature.
+    """
+    sig = inspect.signature(func)
+    field_definitions: Dict[str, Any] = {}
+
+    skip_params = {"self", "context"}
+
+    for param_name, param in sig.parameters.items():
+        if param_name in skip_params:
+            continue
+
+        annotation = (
+            param.annotation if param.annotation != inspect.Parameter.empty else str
+        )
+
+        if param.default != inspect.Parameter.empty:
+            field_definitions[param_name] = (annotation, param.default)
+        else:
+            field_definitions[param_name] = (annotation, ...)
+
+    schema_class_name = f"{name.title().replace('_', '')}Schema"
+    model = create_model(
+        schema_class_name,
+        __config__=ConfigDict(extra="forbid"),
+        **field_definitions,
+    )
+    return model
+
+
+def protocol_command(name: str | None = None) -> Callable:
+    """Decorator that registers a function as a protocol YAML command.
+
+    Usage::
+
+        @protocol_command("move")
+        def move(context: ProtocolContext, instrument: str, position: str) -> None:
+            ...
+
+    Or with the function name as the command name::
+
+        @protocol_command()
+        def move(context: ProtocolContext, instrument: str, position: str) -> None:
+            ...
+    """
+    def decorator(func: Callable) -> Callable:
+        cmd_name = name or func.__name__
+        schema = _build_schema_from_signature(cmd_name, func)
+        CommandRegistry.instance().register(cmd_name, func, schema)
+        func._protocol_command_name = cmd_name  # type: ignore[attr-defined]
+        func._protocol_schema = schema  # type: ignore[attr-defined]
+        return func
+    return decorator

--- a/src/protocol_engine/yaml_schema.py
+++ b/src/protocol_engine/yaml_schema.py
@@ -1,0 +1,70 @@
+"""Strict Pydantic schemas for protocol YAML."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from pydantic import BaseModel, ConfigDict, model_validator
+
+from .registry import CommandRegistry
+
+
+class ProtocolStepSchema(BaseModel):
+    """One step in a protocol: a single command name with its arguments.
+
+    YAML format::
+
+        - move:
+            instrument: pipette
+            position: plate_1.A1
+
+    Parsed as ``{"move": {"instrument": "pipette", "position": "plate_1.A1"}}``,
+    then normalised to ``{"command": "move", "args": {...}}``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    command: str
+    args: Dict[str, Any]
+
+    @model_validator(mode="before")
+    @classmethod
+    def _parse_command_dict(cls, data: Any) -> Any:
+        """Convert ``{command_name: {args}}`` to ``{command: name, args: {…}}``."""
+        if isinstance(data, dict) and "command" not in data:
+            if len(data) != 1:
+                raise ValueError(
+                    f"Each protocol step must have exactly one command, "
+                    f"got {len(data)} keys: {list(data.keys())}. "
+                    "Write each command as a separate list item."
+                )
+            command_name = next(iter(data))
+            args = data[command_name]
+            if args is None:
+                args = {}
+            if not isinstance(args, dict):
+                raise ValueError(
+                    f"Arguments for command '{command_name}' must be a mapping "
+                    f"(key: value), got {type(args).__name__}."
+                )
+            return {"command": command_name, "args": args}
+        return data
+
+    @model_validator(mode="after")
+    def _validate_command_registered(self) -> "ProtocolStepSchema":
+        """Ensure the command is registered and args match its schema."""
+        registry = CommandRegistry.instance()
+        try:
+            registered = registry.get(self.command)
+        except KeyError as exc:
+            raise ValueError(str(exc)) from exc
+        registered.schema.model_validate(self.args)
+        return self
+
+
+class ProtocolYamlSchema(BaseModel):
+    """Root protocol YAML schema: top-level ``protocol`` key with list of steps."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    protocol: List[ProtocolStepSchema]

--- a/tests/protocol_engine/test_loader.py
+++ b/tests/protocol_engine/test_loader.py
@@ -1,0 +1,156 @@
+"""Tests for protocol YAML loading and compilation."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from src.protocol_engine.errors import ProtocolLoaderError
+from src.protocol_engine.loader import load_protocol_from_yaml, load_protocol_from_yaml_safe
+from src.protocol_engine.protocol import Protocol
+
+
+# ─── Valid protocol YAML fixtures ─────────────────────────────────────────────
+
+VALID_SINGLE_MOVE = """
+protocol:
+  - move:
+      instrument: pipette
+      position: plate_1.A1
+"""
+
+VALID_TWO_MOVES = """
+protocol:
+  - move:
+      instrument: pipette
+      position: plate_1.A1
+  - move:
+      instrument: pipette
+      position: plate_1.C9
+"""
+
+
+def _write_yaml(content: str) -> str:
+    """Write YAML content to a temp file and return its path."""
+    f = tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False)
+    f.write(content)
+    f.close()
+    return f.name
+
+
+# ─── Valid loading ────────────────────────────────────────────────────────────
+
+
+def test_load_valid_protocol_returns_protocol():
+    path = _write_yaml(VALID_SINGLE_MOVE)
+    try:
+        protocol = load_protocol_from_yaml(path)
+        assert isinstance(protocol, Protocol)
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_loaded_protocol_has_correct_step_count():
+    path = _write_yaml(VALID_TWO_MOVES)
+    try:
+        protocol = load_protocol_from_yaml(path)
+        assert len(protocol) == 2
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_loaded_protocol_step_has_correct_command_name():
+    path = _write_yaml(VALID_SINGLE_MOVE)
+    try:
+        protocol = load_protocol_from_yaml(path)
+        assert protocol.steps[0].command_name == "move"
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_loaded_protocol_step_has_correct_args():
+    path = _write_yaml(VALID_SINGLE_MOVE)
+    try:
+        protocol = load_protocol_from_yaml(path)
+        args = protocol.steps[0].args
+        assert args == {"instrument": "pipette", "position": "plate_1.A1"}
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_loaded_protocol_has_source_path():
+    path = _write_yaml(VALID_SINGLE_MOVE)
+    try:
+        protocol = load_protocol_from_yaml(path)
+        assert protocol.source_path == Path(path)
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+# ─── Safe loader error formatting ────────────────────────────────────────────
+
+
+def test_safe_loader_unknown_command_has_clean_error():
+    yaml = """
+protocol:
+  - unknown_cmd:
+      a: b
+"""
+    path = _write_yaml(yaml)
+    try:
+        with pytest.raises(ProtocolLoaderError) as exc_info:
+            load_protocol_from_yaml_safe(path)
+        message = str(exc_info.value)
+        assert "Protocol YAML error" in message
+        assert "How to fix:" in message
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_safe_loader_extra_args_has_clean_error():
+    yaml = """
+protocol:
+  - move:
+      instrument: pipette
+      position: plate_1.A1
+      extra_field: bad
+"""
+    path = _write_yaml(yaml)
+    try:
+        with pytest.raises(ProtocolLoaderError) as exc_info:
+            load_protocol_from_yaml_safe(path)
+        message = str(exc_info.value)
+        assert "How to fix:" in message
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_safe_loader_yaml_parse_error_has_clean_error():
+    bad_yaml = "protocol:\n  - move:\n    instrument: [\n"
+    path = _write_yaml(bad_yaml)
+    try:
+        with pytest.raises(ProtocolLoaderError) as exc_info:
+            load_protocol_from_yaml_safe(path)
+        message = str(exc_info.value)
+        assert "parse error" in message.lower()
+        assert "How to fix:" in message
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_safe_loader_missing_file_has_clean_error():
+    missing_path = "/tmp/this_protocol_does_not_exist_12345.yaml"
+    with pytest.raises(ProtocolLoaderError) as exc_info:
+        load_protocol_from_yaml_safe(missing_path)
+    message = str(exc_info.value)
+    assert "Protocol loader error" in message
+    assert "How to fix:" in message
+
+
+def test_empty_yaml_fails():
+    path = _write_yaml("")
+    try:
+        with pytest.raises(Exception):
+            load_protocol_from_yaml(path)
+    finally:
+        Path(path).unlink(missing_ok=True)

--- a/tests/protocol_engine/test_move_command.py
+++ b/tests/protocol_engine/test_move_command.py
@@ -1,0 +1,158 @@
+"""Tests for the move protocol command — unit and end-to-end."""
+
+import logging
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.deck.labware.labware import Coordinate3D
+from src.protocol_engine.loader import load_protocol_from_yaml
+from src.protocol_engine.protocol import Protocol, ProtocolContext, ProtocolStep
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _mock_context(
+    resolve_return: Coordinate3D | None = None,
+) -> ProtocolContext:
+    """Create a ProtocolContext with mock board and deck."""
+    coord = resolve_return or Coordinate3D(x=-10.0, y=-10.0, z=-15.0)
+
+    board = MagicMock()
+    deck = MagicMock()
+    deck.resolve.return_value = coord
+
+    return ProtocolContext(
+        board=board,
+        deck=deck,
+        logger=logging.getLogger("test_move"),
+    )
+
+
+# ─── Unit tests for the move handler ─────────────────────────────────────────
+
+
+class TestMoveCommand:
+
+    def test_move_resolves_position(self):
+        # Import here so the registry is populated
+        from src.protocol_engine.commands.move import move
+
+        ctx = _mock_context()
+        move(ctx, instrument="pipette", position="plate_1.A1")
+
+        ctx.deck.resolve.assert_called_once_with("plate_1.A1")
+
+    def test_move_calls_board_move_with_instrument_and_coord(self):
+        from src.protocol_engine.commands.move import move
+
+        coord = Coordinate3D(x=-10.0, y=-20.0, z=-5.0)
+        ctx = _mock_context(resolve_return=coord)
+
+        move(ctx, instrument="pipette", position="plate_1.A1")
+
+        ctx.board.move.assert_called_once_with("pipette", coord)
+
+    def test_move_passes_instrument_name_through(self):
+        from src.protocol_engine.commands.move import move
+
+        ctx = _mock_context()
+        move(ctx, instrument="filmetrics", position="vial_1")
+
+        ctx.board.move.assert_called_once()
+        call_args = ctx.board.move.call_args
+        assert call_args[0][0] == "filmetrics"
+
+    def test_move_invalid_target_propagates_error(self):
+        from src.protocol_engine.commands.move import move
+
+        ctx = _mock_context()
+        ctx.deck.resolve.side_effect = KeyError("No labware 'bad' on deck.")
+
+        with pytest.raises(KeyError, match="bad"):
+            move(ctx, instrument="pipette", position="bad.A1")
+
+
+# ─── End-to-end: YAML → load → run ──────────────────────────────────────────
+
+
+class TestMoveEndToEnd:
+
+    def test_yaml_to_execution(self):
+        yaml_content = """
+protocol:
+  - move:
+      instrument: pipette
+      position: plate_1.A1
+  - move:
+      instrument: pipette
+      position: plate_1.C9
+"""
+        coord_a1 = Coordinate3D(x=-10.0, y=-10.0, z=-15.0)
+        coord_c9 = Coordinate3D(x=62.0, y=-28.0, z=-15.0)
+
+        # Set up deck to return different coords based on target
+        deck = MagicMock()
+
+        def resolve_side_effect(target: str) -> Coordinate3D:
+            if target == "plate_1.A1":
+                return coord_a1
+            if target == "plate_1.C9":
+                return coord_c9
+            raise KeyError(f"No labware for '{target}'")
+
+        deck.resolve.side_effect = resolve_side_effect
+        board = MagicMock()
+
+        ctx = ProtocolContext(
+            board=board,
+            deck=deck,
+            logger=logging.getLogger("test_e2e"),
+        )
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            path = f.name
+        try:
+            protocol = load_protocol_from_yaml(path)
+            assert len(protocol) == 2
+
+            protocol.run(ctx)
+
+            # deck.resolve called once per step
+            assert deck.resolve.call_count == 2
+            deck.resolve.assert_any_call("plate_1.A1")
+            deck.resolve.assert_any_call("plate_1.C9")
+
+            # board.move called once per step with correct args
+            assert board.move.call_count == 2
+            board.move.assert_any_call("pipette", coord_a1)
+            board.move.assert_any_call("pipette", coord_c9)
+        finally:
+            Path(path).unlink(missing_ok=True)
+
+    def test_yaml_single_move_runs(self):
+        yaml_content = """
+protocol:
+  - move:
+      instrument: pipette
+      position: vial_1
+"""
+        coord = Coordinate3D(x=-30.0, y=-40.0, z=-20.0)
+        ctx = _mock_context(resolve_return=coord)
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            path = f.name
+        try:
+            protocol = load_protocol_from_yaml(path)
+            results = protocol.run(ctx)
+
+            assert len(results) == 1
+            ctx.deck.resolve.assert_called_once_with("vial_1")
+            ctx.board.move.assert_called_once_with("pipette", coord)
+        finally:
+            Path(path).unlink(missing_ok=True)

--- a/tests/protocol_engine/test_protocol.py
+++ b/tests/protocol_engine/test_protocol.py
@@ -1,0 +1,114 @@
+"""Tests for Protocol, ProtocolStep, and ProtocolContext runtime classes."""
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.protocol_engine.protocol import Protocol, ProtocolContext, ProtocolStep
+
+
+def _mock_context():
+    return ProtocolContext(
+        board=MagicMock(),
+        deck=MagicMock(),
+        logger=logging.getLogger("test_protocol"),
+    )
+
+
+# ─── ProtocolStep ────────────────────────────────────────────────────────────
+
+
+class TestProtocolStep:
+
+    def test_execute_calls_handler_with_context_and_kwargs(self):
+        handler = MagicMock(return_value="ok")
+        step = ProtocolStep(
+            index=0,
+            command_name="move",
+            handler=handler,
+            args={"instrument": "pipette", "position": "plate_1.A1"},
+        )
+        ctx = _mock_context()
+        result = step.execute(ctx)
+
+        handler.assert_called_once_with(ctx, instrument="pipette", position="plate_1.A1")
+        assert result == "ok"
+
+    def test_execute_with_empty_args(self):
+        handler = MagicMock(return_value=None)
+        step = ProtocolStep(index=0, command_name="home", handler=handler, args={})
+        ctx = _mock_context()
+        step.execute(ctx)
+
+        handler.assert_called_once_with(ctx)
+
+
+# ─── Protocol ────────────────────────────────────────────────────────────────
+
+
+class TestProtocol:
+
+    def test_run_executes_all_steps_in_order(self):
+        call_order = []
+        handler_a = MagicMock(side_effect=lambda ctx, **kw: call_order.append("a"))
+        handler_b = MagicMock(side_effect=lambda ctx, **kw: call_order.append("b"))
+
+        steps = [
+            ProtocolStep(index=0, command_name="a", handler=handler_a, args={"x": "1"}),
+            ProtocolStep(index=1, command_name="b", handler=handler_b, args={"y": "2"}),
+        ]
+        protocol = Protocol(steps=steps)
+        ctx = _mock_context()
+        protocol.run(ctx)
+
+        assert call_order == ["a", "b"]
+
+    def test_run_passes_context_to_handlers(self):
+        handler = MagicMock(return_value=None)
+        steps = [ProtocolStep(index=0, command_name="cmd", handler=handler, args={})]
+        protocol = Protocol(steps=steps)
+        ctx = _mock_context()
+        protocol.run(ctx)
+
+        handler.assert_called_once_with(ctx)
+
+    def test_run_returns_results_list(self):
+        handler_a = MagicMock(return_value="result_a")
+        handler_b = MagicMock(return_value="result_b")
+
+        steps = [
+            ProtocolStep(index=0, command_name="a", handler=handler_a, args={}),
+            ProtocolStep(index=1, command_name="b", handler=handler_b, args={}),
+        ]
+        protocol = Protocol(steps=steps)
+        results = protocol.run(_mock_context())
+
+        assert results == ["result_a", "result_b"]
+
+    def test_empty_protocol_run_succeeds(self):
+        protocol = Protocol(steps=[])
+        results = protocol.run(_mock_context())
+        assert results == []
+
+    def test_protocol_len(self):
+        steps = [
+            ProtocolStep(index=0, command_name="a", handler=MagicMock(), args={}),
+            ProtocolStep(index=1, command_name="b", handler=MagicMock(), args={}),
+        ]
+        assert len(Protocol(steps=steps)) == 2
+        assert len(Protocol(steps=[])) == 0
+
+    def test_protocol_repr(self):
+        steps = [
+            ProtocolStep(index=0, command_name="move", handler=MagicMock(), args={}),
+            ProtocolStep(index=1, command_name="aspirate", handler=MagicMock(), args={}),
+        ]
+        assert repr(Protocol(steps=steps)) == "Protocol([move, aspirate])"
+
+    def test_protocol_steps_property_returns_copy(self):
+        steps = [ProtocolStep(index=0, command_name="a", handler=MagicMock(), args={})]
+        protocol = Protocol(steps=steps)
+        returned = protocol.steps
+        returned.append(ProtocolStep(index=1, command_name="b", handler=MagicMock(), args={}))
+        assert len(protocol) == 1

--- a/tests/protocol_engine/test_registry.py
+++ b/tests/protocol_engine/test_registry.py
@@ -1,0 +1,158 @@
+"""Tests for the @protocol_command decorator and CommandRegistry."""
+
+import pytest
+from pydantic import ValidationError
+
+from src.protocol_engine.registry import (
+    CommandRegistry,
+    _build_schema_from_signature,
+    protocol_command,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_registry():
+    """Reset the singleton before and after each test."""
+    CommandRegistry.reset()
+    yield
+    CommandRegistry.reset()
+
+
+# ─── Registration ────────────────────────────────────────────────────────────
+
+
+def test_protocol_command_registers_function():
+    @protocol_command("greet")
+    def greet(context, name: str) -> None:
+        pass
+
+    reg = CommandRegistry.instance()
+    assert "greet" in reg.command_names
+    assert reg.get("greet").handler is greet
+
+
+def test_protocol_command_uses_function_name_by_default():
+    @protocol_command()
+    def hello(context, msg: str) -> None:
+        pass
+
+    assert "hello" in CommandRegistry.instance().command_names
+
+
+def test_protocol_command_uses_explicit_name():
+    @protocol_command("custom_name")
+    def my_func(context, x: int) -> None:
+        pass
+
+    reg = CommandRegistry.instance()
+    assert "custom_name" in reg.command_names
+    assert reg.get("custom_name").handler is my_func
+
+
+def test_duplicate_command_name_raises():
+    @protocol_command("dup")
+    def first(context) -> None:
+        pass
+
+    with pytest.raises(ValueError, match="already registered"):
+
+        @protocol_command("dup")
+        def second(context) -> None:
+            pass
+
+
+def test_get_unknown_command_raises():
+    reg = CommandRegistry.instance()
+    with pytest.raises(KeyError, match="Unknown protocol command 'nope'"):
+        reg.get("nope")
+
+
+def test_get_unknown_command_lists_available():
+    @protocol_command("alpha")
+    def alpha(context) -> None:
+        pass
+
+    @protocol_command("beta")
+    def beta(context) -> None:
+        pass
+
+    reg = CommandRegistry.instance()
+    with pytest.raises(KeyError, match="alpha.*beta"):
+        reg.get("nope")
+
+
+def test_reset_clears_registry():
+    @protocol_command("tmp")
+    def tmp(context) -> None:
+        pass
+
+    assert "tmp" in CommandRegistry.instance().command_names
+    CommandRegistry.reset()
+    assert CommandRegistry.instance().command_names == []
+
+
+def test_decorator_attaches_metadata():
+    @protocol_command("meta")
+    def meta(context, x: str) -> None:
+        pass
+
+    assert meta._protocol_command_name == "meta"
+    assert meta._protocol_schema is not None
+
+
+# ─── Schema generation ───────────────────────────────────────────────────────
+
+
+def test_schema_generated_with_correct_fields():
+    def sample(context, instrument: str, position: str) -> None:
+        pass
+
+    schema = _build_schema_from_signature("sample", sample)
+    fields = set(schema.model_fields.keys())
+    assert fields == {"instrument", "position"}
+
+
+def test_schema_skips_context_and_self():
+    def method(self, context, value: int) -> None:
+        pass
+
+    schema = _build_schema_from_signature("method", method)
+    assert set(schema.model_fields.keys()) == {"value"}
+
+
+def test_schema_forbids_extra_fields():
+    def cmd(context, a: str) -> None:
+        pass
+
+    schema = _build_schema_from_signature("cmd", cmd)
+    with pytest.raises(ValidationError, match="Extra inputs"):
+        schema.model_validate({"a": "ok", "b": "extra"})
+
+
+def test_schema_requires_all_parameters():
+    def cmd(context, a: str, b: int) -> None:
+        pass
+
+    schema = _build_schema_from_signature("cmd", cmd)
+    with pytest.raises(ValidationError):
+        schema.model_validate({"a": "only_a"})
+
+
+def test_schema_respects_default_values():
+    def cmd(context, a: str, b: float = 50.0) -> None:
+        pass
+
+    schema = _build_schema_from_signature("cmd", cmd)
+    result = schema.model_validate({"a": "hello"})
+    assert result.a == "hello"
+    assert result.b == 50.0
+
+
+def test_schema_validates_successfully_with_all_fields():
+    def cmd(context, instrument: str, position: str) -> None:
+        pass
+
+    schema = _build_schema_from_signature("cmd", cmd)
+    result = schema.model_validate({"instrument": "pipette", "position": "plate_1.A1"})
+    assert result.instrument == "pipette"
+    assert result.position == "plate_1.A1"

--- a/tests/protocol_engine/test_yaml_schema.py
+++ b/tests/protocol_engine/test_yaml_schema.py
@@ -1,0 +1,138 @@
+"""Tests for protocol YAML schema validation."""
+
+import pytest
+from pydantic import ValidationError
+
+from src.protocol_engine.registry import CommandRegistry, protocol_command
+from src.protocol_engine.yaml_schema import ProtocolStepSchema, ProtocolYamlSchema
+
+
+@pytest.fixture(autouse=True)
+def _fresh_registry():
+    """Reset and populate registry with a test 'move' command."""
+    CommandRegistry.reset()
+
+    @protocol_command("move")
+    def move(context, instrument: str, position: str) -> None:
+        pass
+
+    yield
+    CommandRegistry.reset()
+
+
+# ─── Valid schemas ───────────────────────────────────────────────────────────
+
+
+def test_valid_single_move_step():
+    data = {
+        "protocol": [
+            {"move": {"instrument": "pipette", "position": "plate_1.A1"}},
+        ]
+    }
+    schema = ProtocolYamlSchema.model_validate(data)
+    assert len(schema.protocol) == 1
+    assert schema.protocol[0].command == "move"
+    assert schema.protocol[0].args == {"instrument": "pipette", "position": "plate_1.A1"}
+
+
+def test_valid_multiple_steps():
+    data = {
+        "protocol": [
+            {"move": {"instrument": "pipette", "position": "plate_1.A1"}},
+            {"move": {"instrument": "pipette", "position": "plate_1.C9"}},
+        ]
+    }
+    schema = ProtocolYamlSchema.model_validate(data)
+    assert len(schema.protocol) == 2
+
+
+def test_empty_protocol_list_allowed():
+    data = {"protocol": []}
+    schema = ProtocolYamlSchema.model_validate(data)
+    assert len(schema.protocol) == 0
+
+
+# ─── Top-level validation ───────────────────────────────────────────────────
+
+
+def test_extra_top_level_key_fails():
+    data = {
+        "protocol": [],
+        "extra_key": "bad",
+    }
+    with pytest.raises(ValidationError):
+        ProtocolYamlSchema.model_validate(data)
+
+
+def test_missing_protocol_key_fails():
+    with pytest.raises(ValidationError):
+        ProtocolYamlSchema.model_validate({"other": []})
+
+
+# ─── Step-level validation ───────────────────────────────────────────────────
+
+
+def test_unknown_command_name_fails():
+    data = {
+        "protocol": [
+            {"unknown_cmd": {"a": "b"}},
+        ]
+    }
+    with pytest.raises((ValidationError, KeyError)):
+        ProtocolYamlSchema.model_validate(data)
+
+
+def test_extra_command_args_fail():
+    data = {
+        "protocol": [
+            {"move": {"instrument": "pipette", "position": "plate_1.A1", "extra": "bad"}},
+        ]
+    }
+    with pytest.raises(ValidationError):
+        ProtocolYamlSchema.model_validate(data)
+
+
+def test_missing_required_args_fail():
+    data = {
+        "protocol": [
+            {"move": {"instrument": "pipette"}},
+        ]
+    }
+    with pytest.raises(ValidationError):
+        ProtocolYamlSchema.model_validate(data)
+
+
+def test_multi_command_per_step_fails():
+    data = {
+        "protocol": [
+            {"move": {"instrument": "pipette", "position": "p.A1"}, "other": {}},
+        ]
+    }
+    with pytest.raises(ValidationError, match="exactly one command"):
+        ProtocolYamlSchema.model_validate(data)
+
+
+def test_non_dict_args_fail():
+    data = {
+        "protocol": [
+            {"move": "plate_1.A1"},
+        ]
+    }
+    with pytest.raises(ValidationError, match="must be a mapping"):
+        ProtocolYamlSchema.model_validate(data)
+
+
+def test_command_with_null_args_normalised_to_empty_dict():
+    """Register a no-arg command and verify null args parse as empty dict."""
+    @protocol_command("home")
+    def home(context) -> None:
+        pass
+
+    data = {
+        "protocol": [
+            {"home": None},
+        ]
+    }
+    schema = ProtocolYamlSchema.model_validate(data)
+    assert schema.protocol[0].command == "home"
+    assert schema.protocol[0].args == {}


### PR DESCRIPTION
…tration

Introduces a YAML-to-Python protocol compilation system that mirrors the existing deck YAML pipeline. Protocol commands are registered via a @protocol_command decorator that introspects function signatures to auto-generate strict Pydantic validation schemas (extra="forbid").

Architecture:
- registry.py: CommandRegistry singleton + @protocol_command decorator
- yaml_schema.py: ProtocolYamlSchema/ProtocolStepSchema with before/after validators
- protocol.py: ProtocolContext, ProtocolStep, Protocol runtime classes
- loader.py: load_protocol_from_yaml() compiler pipeline
- commands/move.py: First command, maps 1:1 to Board.move(instrument, position)
- errors.py: ProtocolLoaderError, ProtocolExecutionError

The move command resolves deck target strings (e.g. "plate_1.A1") via Deck.resolve() and delegates to Board.move() for gantry execution.

All 292 tests pass (50 new protocol engine tests + 242 existing).

https://claude.ai/code/session_01K9JAxHiCmYLM5gfLMDeZvh