### PR TITLE
Standardize coordinate system to Work Position (WPos) only

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,128 @@
+# Plan: Manual Homing Strategy for Genmitsu 3018 PRO Desktop
+
+## Context
+The Genmitsu 3018 PRO Desktop has **no homing switches**. The user manually jogs
+the machine to the origin corner before the software takes over. All coordinates
+are **positive** (X: 0–280, Y: 0–170, Z: 0–40). Z=0 is retracted (safe height),
+Z increases downward toward the deck.
+
+## Coordinate Convention
+- **Origin (0, 0, 0):** Front-left corner, gantry fully retracted (Z at top)
+- **X+:** Moves right (0 → 280)
+- **Y+:** Moves away from operator (0 → 170)
+- **Z+:** Moves down toward deck surface (0 → 40)
+- **Safe Z:** Z=0 (fully retracted)
+
+## Changes
+
+### 1. New homing strategy: `manual`
+
+**`src/gantry/gantry_config.py`**
+- Add `MANUAL = "manual"` to `HomingStrategy` enum
+
+**`src/gantry/yaml_schema.py`**
+- Add `"manual"` to the `homing_strategy` Literal type
+
+### 2. `home_manual()` method in driver
+
+**`src/gantry/gantry_driver/driver.py`**
+- New method `home_manual()`:
+  1. Prints a prompt: "Jog the machine to the origin position (front-left, Z fully retracted), then press Enter."
+  2. Blocks on `input()` until user confirms
+  3. Sends `G10 L20 P1 X0 Y0 Z0` — sets current WPos to (0,0,0)
+  4. Sends `G90` — enforce absolute mode
+  5. Sets `self.homed = True`
+  6. Logs the action
+
+### 3. Configure GRBL soft limits on connect
+
+**`src/gantry/gantry_driver/driver.py`**
+- New method `configure_soft_limits(x_max, y_max, z_max)`:
+  1. Sends `$20=1` (enable soft limits)
+  2. Sends `$130={x_max}` (X max travel)
+  3. Sends `$131={y_max}` (Y max travel)
+  4. Sends `$132={z_max}` (Z max travel)
+  5. Updates `self.config` for each
+- This will be called from `Gantry.home()` or `connect()` when
+  the config provides working volume bounds and strategy is `manual`.
+
+### 4. Wire into Gantry.home()
+
+**`src/gantry/gantry.py`**
+- Add `elif strategy == "manual":` branch that calls `self._mill.home_manual()`
+- After homing, call `self._mill.configure_soft_limits(280, 170, 40)` using
+  values from the working volume config
+
+### 5. Update Genmitsu YAML config
+
+**`configs/gantry/genmitsu_3018_PRO_Desktop.yaml`**
+```yaml
+serial_port: /dev/cu.usbserial-2130
+cnc:
+  homing_strategy: manual
+
+working_volume:
+  x_min: 0.0
+  x_max: 280.0
+  y_min: 0.0
+  y_max: 170.0
+  z_min: 0.0
+  z_max: 40.0
+```
+
+### 6. Update safe_z_height and max_z_height defaults
+
+Currently `safe_z_height = -10.0` and `max_z_height = 0.0`. With positive-Z-down:
+- `max_z_height` = 0.0 (top of travel — this already works)
+- `safe_z_height` should be a small positive number like 2.0 (slightly below retracted,
+  enough clearance to safely traverse XY)
+
+This needs to be configurable or derived from the working volume, but for now
+the manual homing method will set `self.max_z_height = 0.0` (already correct)
+and note that `safe_z_height` should be set to a small positive value for
+positive-Z-down setups. We can wire this through config in a follow-up.
+
+### 7. MockMill update
+
+**`src/gantry/gantry_driver/mock.py`**
+- Add `home_manual()` stub that sets coordinates to (0,0,0) and `self.homed = True`
+
+### 8. Tests (TDD)
+
+**`tests/gantry/driver/test_manual_homing.py`** — New test file:
+- `test_home_manual_sets_wpos_to_zero` — verifies `G10 L20 P1 X0 Y0 Z0` is sent
+- `test_home_manual_enforces_g90` — verifies G90 is sent after setting origin
+- `test_home_manual_sets_homed_flag` — verifies `self.homed = True`
+- `test_home_manual_prompts_user` — verifies `input()` is called (mocked)
+- `test_configure_soft_limits_sends_correct_commands` — verifies $20=1, $130, $131, $132
+- `test_configure_soft_limits_updates_config` — verifies config dict updated
+
+**`tests/gantry/test_gantry.py`** — Add:
+- `test_home_with_manual_strategy` — verifies Gantry.home() calls `home_manual()`
+
+**`tests/gantry/test_yaml_schema.py`** — Add:
+- `test_manual_homing_strategy_accepted` — verifies "manual" is valid in schema
+
+### 9. Update AGENTS.md / README.md
+- Document the new `manual` homing strategy and positive coordinate convention
+
+## Files Changed (summary)
+| File | Change |
+|------|--------|
+| `src/gantry/gantry_config.py` | Add `MANUAL` enum value |
+| `src/gantry/yaml_schema.py` | Add `"manual"` to Literal |
+| `src/gantry/gantry_driver/driver.py` | Add `home_manual()`, `configure_soft_limits()` |
+| `src/gantry/gantry.py` | Wire manual strategy in `home()` |
+| `src/gantry/gantry_driver/mock.py` | Add `home_manual()` stub |
+| `configs/gantry/genmitsu_3018_PRO_Desktop.yaml` | Update to manual + positive coords |
+| `tests/gantry/driver/test_manual_homing.py` | New: 6+ tests |
+| `tests/gantry/test_gantry.py` | Add manual strategy test |
+| `tests/gantry/test_yaml_schema.py` | Add manual schema test |
+| `AGENTS.md` / `README.md` | Document new strategy |
+| `progress/2026-02-19.md` | Update progress |
+
+## What This Does NOT Change
+- No changes to `current_coordinates()` — WPos enforcement already handles this
+- No changes to movement commands — they already use WPos + G90
+- No changes to instrument offsets — they work the same in positive coordinate space
+- The existing `standard` and `xy_hard_limits` strategies are untouched

--- a/plan.md
+++ b/plan.md
@@ -2,16 +2,17 @@
 
 ## Context
 The Genmitsu 3018 PRO Desktop has **no homing switches**. The user manually jogs
-the machine to the origin corner before the software takes over. All coordinates
-are **positive** (X: 0–280, Y: 0–170, Z: 0–40). Z=0 is retracted (safe height),
-Z increases downward toward the deck.
+the machine to the origin corner before the software takes over.
 
-## Coordinate Convention
+## Coordinate Convention (unified across all machines)
 - **Origin (0, 0, 0):** Front-left corner, gantry fully retracted (Z at top)
 - **X+:** Moves right (0 → 280)
 - **Y+:** Moves away from operator (0 → 170)
-- **Z+:** Moves down toward deck surface (0 → 40)
+- **Z-:** Moves down toward deck surface (0 → -40)
 - **Safe Z:** Z=0 (fully retracted)
+
+This matches standard GRBL with homing switches, where Z=0 is at home (top)
+and Z goes negative downward. Both machines share the same movement logic.
 
 ## Changes
 
@@ -43,15 +44,21 @@ Z increases downward toward the deck.
   3. Sends `$131={y_max}` (Y max travel)
   4. Sends `$132={z_max}` (Z max travel)
   5. Updates `self.config` for each
-- This will be called from `Gantry.home()` or `connect()` when
-  the config provides working volume bounds and strategy is `manual`.
+- Called from `Gantry.home()` when the config provides working volume bounds
+  and strategy is `manual`.
+
+Note: GRBL soft limits use the *absolute* travel distance (always positive).
+$132=40 means "40mm of travel on Z". The direction is determined by the
+direction invert mask ($3) and homing direction ($23). The working volume in
+the YAML uses signed values (z_min: -40, z_max: 0) to express the actual
+coordinate range.
 
 ### 4. Wire into Gantry.home()
 
 **`src/gantry/gantry.py`**
 - Add `elif strategy == "manual":` branch that calls `self._mill.home_manual()`
-- After homing, call `self._mill.configure_soft_limits(280, 170, 40)` using
-  values from the working volume config
+- After homing, call `self._mill.configure_soft_limits(280, 170, 40)` deriving
+  the max travel values from the working volume config (x_max - x_min, etc.)
 
 ### 5. Update Genmitsu YAML config
 
@@ -66,21 +73,17 @@ working_volume:
   x_max: 280.0
   y_min: 0.0
   y_max: 170.0
-  z_min: 0.0
-  z_max: 40.0
+  z_min: -40.0
+  z_max: 0.0
 ```
 
-### 6. Update safe_z_height and max_z_height defaults
+### 6. safe_z_height and max_z_height
 
-Currently `safe_z_height = -10.0` and `max_z_height = 0.0`. With positive-Z-down:
-- `max_z_height` = 0.0 (top of travel — this already works)
-- `safe_z_height` should be a small positive number like 2.0 (slightly below retracted,
-  enough clearance to safely traverse XY)
+Both already default correctly:
+- `max_z_height = 0.0` — top of travel, safe retracted position
+- `safe_z_height = -10.0` — threshold below which XY diagonal moves are avoided
 
-This needs to be configurable or derived from the working volume, but for now
-the manual homing method will set `self.max_z_height = 0.0` (already correct)
-and note that `safe_z_height` should be set to a small positive value for
-positive-Z-down setups. We can wire this through config in a follow-up.
+These work as-is with Z=0 top, Z- down. No changes needed.
 
 ### 7. MockMill update
 
@@ -104,7 +107,7 @@ positive-Z-down setups. We can wire this through config in a follow-up.
 - `test_manual_homing_strategy_accepted` — verifies "manual" is valid in schema
 
 ### 9. Update AGENTS.md / README.md
-- Document the new `manual` homing strategy and positive coordinate convention
+- Document the new `manual` homing strategy
 
 ## Files Changed (summary)
 | File | Change |
@@ -114,7 +117,7 @@ positive-Z-down setups. We can wire this through config in a follow-up.
 | `src/gantry/gantry_driver/driver.py` | Add `home_manual()`, `configure_soft_limits()` |
 | `src/gantry/gantry.py` | Wire manual strategy in `home()` |
 | `src/gantry/gantry_driver/mock.py` | Add `home_manual()` stub |
-| `configs/gantry/genmitsu_3018_PRO_Desktop.yaml` | Update to manual + positive coords |
+| `configs/gantry/genmitsu_3018_PRO_Desktop.yaml` | Update to manual + negative Z coords |
 | `tests/gantry/driver/test_manual_homing.py` | New: 6+ tests |
 | `tests/gantry/test_gantry.py` | Add manual strategy test |
 | `tests/gantry/test_yaml_schema.py` | Add manual schema test |
@@ -124,5 +127,6 @@ positive-Z-down setups. We can wire this through config in a follow-up.
 ## What This Does NOT Change
 - No changes to `current_coordinates()` — WPos enforcement already handles this
 - No changes to movement commands — they already use WPos + G90
-- No changes to instrument offsets — they work the same in positive coordinate space
+- No changes to instrument offsets — they work the same with this coordinate convention
+- No changes to `safe_move()` — Z=0 top, Z- down is what it already expects
 - The existing `standard` and `xy_hard_limits` strategies are untouched

--- a/progress/2026-02-19.md
+++ b/progress/2026-02-19.md
@@ -35,3 +35,55 @@
 - 4 source files modified
 - 2 test files updated (18 new tests added, 25 total new tests)
 - 517/517 tests passing
+
+---
+
+## Task: Coordinate System Standardization (WPos Enforcement)
+
+### Problem
+The driver had a latent coordinate system mismatch:
+- `$10=1` in config meant GRBL reported **MPos** (Machine Position) in status queries
+- But all G-code movement commands (`G01`, `G00`) operate in **WPos** (Work Position)
+- `current_coordinates()` read MPos but `move_to_position()` commanded in WPos — two different coordinate systems
+- This worked only by coincidence when WPos == MPos (no work offsets set)
+- The `home_xy_hard_limits()` method sets work offsets via `G10 L20`, which would break this assumption
+- Dead code existed: `if coord_type == "MPos": pass` (unfinished TODO) and unused `homing_pull_off` variable
+
+### Solution: Standardize on WPos
+
+All coordinates in the PANDA system are now exclusively Work Position (WPos).
+
+#### Changes to `src/gantry/gantry_driver/driver.py`:
+1. **Removed `mpos_pattern`** — only `wpos_pattern` remains at module level
+2. **Added `g54_pattern`** — for parsing G54 work coordinate offset from `$#` response
+3. **Added `POST_HOMING_TOLERANCE`** constant (10mm) for post-homing validation
+4. **Added `enforce_wpos_mode()`** — sends `$10=0` to GRBL and updates config; called during `connect_to_mill()`
+5. **Added `enforce_absolute_positioning()`** — sends `G90`; called during `connect_to_mill()` and after `home()` completes
+6. **Added `validate_post_homing_coordinates()`** — verifies WPos is near origin after homing; called in `homing_sequence()`
+7. **Added `machine_coordinates()`** — diagnostic method that computes MPos = WPos + WCO via `$#` query
+8. **Added `_query_work_coordinate_offset()`** — parses G54 offset from GRBL `$#` response
+9. **Simplified `current_coordinates()`** — removed `$10` branching, `mpos_pattern` usage, dead `if coord_type == "MPos": pass`, and unused `homing_pull_off` read. Now only parses WPos.
+10. **Updated `home()`** — enforces G90 after homing completes to prevent stale G91 state
+11. **Updated `homing_sequence()`** — validates post-homing coordinates
+12. **Updated `connect_to_mill()`** — calls `enforce_wpos_mode()` and `enforce_absolute_positioning()` during connection setup
+
+#### Changes to `src/gantry/gantry_driver/mock.py`:
+- Changed all `MPos:` strings to `WPos:` in `MockMill` and `MockSerialToMill` to match the enforced WPos reporting
+
+#### Changes to `tests/gantry/driver/test_gantry_driver.py`:
+- Removed `mpos_pattern` import and MPos-specific test assertions
+- Updated `test_regex_patterns` to verify WPos pattern doesn't match MPos strings
+- Added `enforce_wpos_mode` and `enforce_absolute_positioning` mocks to connection test
+
+#### New test file: `tests/gantry/driver/test_coordinate_system.py` (21 tests)
+- `TestWPosEnforcementOnConnect` (3 tests) — verifies $10=0 enforcement on connect
+- `TestCurrentCoordinatesWPosOnly` (6 tests) — verifies WPos-only parsing, MPos rejection, instrument offsets
+- `TestG90EnforcementOnConnect` (2 tests) — verifies G90 sent on connect
+- `TestG90AfterHoming` (1 test) — verifies G90 sent after homing
+- `TestPostHomingCoordinateValidation` (3 tests) — verifies near-origin check after homing
+- `TestMachineCoordinatesMethod` (3 tests) — verifies MPos = WPos + WCO computation
+- `TestWPosPatternOnly` (3 tests) — verifies mpos_pattern is removed
+
+### Test Results
+- All 98 gantry tests pass (21 new + 77 existing)
+- No regressions in any existing tests

--- a/src/gantry/gantry_driver/mock.py
+++ b/src/gantry/gantry_driver/mock.py
@@ -111,10 +111,10 @@ class MockMill(RealMill):
             raise MillConfigError("Error reading mill config") from exep
 
     def __wait_for_completion(self, incoming_status, timeout=5):
-        return f"<Idle|MPos:{self.ser_mill.current_x - 3},{self.ser_mill.current_y - 3},{self.ser_mill.current_z - 3}|Bf:15,127|FS:0,0>"
+        return f"<Idle|WPos:{self.ser_mill.current_x - 3},{self.ser_mill.current_y - 3},{self.ser_mill.current_z - 3}|Bf:15,127|FS:0,0>"
 
     def __current_status(self):
-        return f"<Idle|MPos:{self.ser_mill.current_x},{self.ser_mill.current_y},{self.ser_mill.current_z}|Bf:15,127|FS:0,0>"
+        return f"<Idle|WPos:{self.ser_mill.current_x},{self.ser_mill.current_y},{self.ser_mill.current_z}|Bf:15,127|FS:0,0>"
 
     def home(self):
         """Simulate homing the mill"""
@@ -196,21 +196,21 @@ class MockSerialToMill:
 
     def read(self, size):
         """Simulate reading from the serial connection"""
-        msg = f"<Idle|MPos:{self.current_x - 3},{self.current_y - 3},{self.current_z - 3}|Bf:15,127|FS:0,0>".encode()
+        msg = f"<Idle|WPos:{self.current_x - 3},{self.current_y - 3},{self.current_z - 3}|Bf:15,127|FS:0,0>".encode()
         return msg[:size]
 
     def read_all(self):
         """Simulate reading from the serial connection"""
-        return f"<Idle|MPos:{self.current_x - 3},{self.current_y - 3},{self.current_z - 3}|Bf:15,127|FS:0,0>\n".encode()
+        return f"<Idle|WPos:{self.current_x - 3},{self.current_y - 3},{self.current_z - 3}|Bf:15,127|FS:0,0>\n".encode()
 
     def readline(self):
         """Simulate reading from the serial connection"""
-        return f"<Idle|MPos:{self.current_x - 3},{self.current_y - 3},{self.current_z - 3}|Bf:15,127|FS:0,0>\n".encode()
+        return f"<Idle|WPos:{self.current_x - 3},{self.current_y - 3},{self.current_z - 3}|Bf:15,127|FS:0,0>\n".encode()
 
     def readlines(self):
         """Simulate reading from the serial connection"""
         return [
-            f"<Idle|MPos:{self.current_x},{self.current_y},{self.current_z}|Bf:15,127|FS:0,0>\n".encode()
+            f"<Idle|WPos:{self.current_x},{self.current_y},{self.current_z}|Bf:15,127|FS:0,0>\n".encode()
         ]
 
     def flushInput(self):

--- a/tests/gantry/driver/test_coordinate_system.py
+++ b/tests/gantry/driver/test_coordinate_system.py
@@ -1,0 +1,361 @@
+"""Tests for coordinate system standardization.
+
+All coordinates in the PANDA system are Work Position (WPos).
+The driver enforces $10=0 on connect and G90 (absolute mode) after homing.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch, call
+from pathlib import Path
+
+from gantry.gantry_driver.driver import Mill, wpos_pattern, Coordinates
+from gantry.gantry_driver.exceptions import LocationNotFound, StatusReturnError
+
+
+class TestWPosEnforcementOnConnect(unittest.TestCase):
+    """$10=0 must be sent during connect_to_mill to enforce WPos reporting."""
+
+    @patch("gantry.gantry_driver.driver.serial.Serial")
+    @patch("gantry.gantry_driver.driver.set_up_mill_logger")
+    @patch("gantry.gantry_driver.driver.set_up_command_logger")
+    def test_connect_enforces_wpos_mode(
+        self, mock_cmd_logger, mock_mill_logger, mock_serial
+    ):
+        mock_serial_instance = MagicMock()
+        mock_serial_instance.is_open = True
+        mock_serial.return_value = mock_serial_instance
+
+        with patch.object(
+            Mill,
+            "locate_mill_over_serial",
+            return_value=(mock_serial_instance, "/dev/test"),
+        ):
+            mill = Mill()
+            mill.read_mill_config = MagicMock()
+            mill.write_mill_config_file = MagicMock()
+            mill.read_working_volume = MagicMock()
+            mill.check_for_alarm_state = MagicMock()
+            mill.clear_buffers = MagicMock()
+            mill.set_feed_rate = MagicMock()
+            mill.enforce_wpos_mode = MagicMock()
+            mill.enforce_absolute_positioning = MagicMock()
+
+            mill.connect_to_mill(port="/dev/test")
+
+            mill.enforce_wpos_mode.assert_called_once()
+
+    @patch("gantry.gantry_driver.driver.serial.Serial")
+    @patch("gantry.gantry_driver.driver.set_up_mill_logger")
+    @patch("gantry.gantry_driver.driver.set_up_command_logger")
+    def test_enforce_wpos_mode_sends_correct_setting(
+        self, mock_cmd_logger, mock_mill_logger, mock_serial
+    ):
+        mill = Mill()
+        mill.ser_mill = MagicMock()
+        mill.execute_command = MagicMock()
+
+        mill.enforce_wpos_mode()
+
+        mill.execute_command.assert_called_with("$10=0")
+
+    @patch("gantry.gantry_driver.driver.serial.Serial")
+    @patch("gantry.gantry_driver.driver.set_up_mill_logger")
+    @patch("gantry.gantry_driver.driver.set_up_command_logger")
+    def test_enforce_wpos_mode_updates_config(
+        self, mock_cmd_logger, mock_mill_logger, mock_serial
+    ):
+        mill = Mill()
+        mill.ser_mill = MagicMock()
+        mill.execute_command = MagicMock()
+        mill.config["$10"] = "1"
+
+        mill.enforce_wpos_mode()
+
+        self.assertEqual(mill.config["$10"], "0")
+
+
+class TestCurrentCoordinatesWPosOnly(unittest.TestCase):
+    """current_coordinates() must only parse WPos, never MPos."""
+
+    @patch("gantry.gantry_driver.driver.serial.Serial")
+    @patch("gantry.gantry_driver.driver.set_up_mill_logger")
+    @patch("gantry.gantry_driver.driver.set_up_command_logger")
+    def _make_mill(self, mock_cmd_logger, mock_mill_logger, mock_serial):
+        mill = Mill()
+        mill.ser_mill = MagicMock()
+        return mill
+
+    def test_parses_wpos_status(self):
+        mill = self._make_mill()
+        mill.ser_mill.write = MagicMock()
+        mill.read = MagicMock(
+            return_value="<Idle|WPos:10.500,20.123,-5.000|FS:0,0>"
+        )
+
+        coords = mill.current_coordinates()
+
+        self.assertEqual(coords.x, 10.5)
+        self.assertEqual(coords.y, 20.123)
+        self.assertEqual(coords.z, -5.0)
+
+    def test_raises_on_mpos_only_status(self):
+        """If the machine somehow returns MPos instead of WPos, we should fail clearly."""
+        mill = self._make_mill()
+        mill.ser_mill.write = MagicMock()
+        mill.read = MagicMock(
+            return_value="<Idle|MPos:-400.123,-299.999,-10.000|FS:0,0>"
+        )
+
+        with self.assertRaises(LocationNotFound):
+            mill.current_coordinates()
+
+    def test_parses_wpos_with_zero_coordinates(self):
+        mill = self._make_mill()
+        mill.ser_mill.write = MagicMock()
+        mill.read = MagicMock(
+            return_value="<Idle|WPos:0.000,0.000,0.000|FS:0,0>"
+        )
+
+        coords = mill.current_coordinates()
+
+        self.assertEqual(coords.x, 0.0)
+        self.assertEqual(coords.y, 0.0)
+        self.assertEqual(coords.z, 0.0)
+
+    def test_parses_wpos_with_negative_coordinates(self):
+        mill = self._make_mill()
+        mill.ser_mill.write = MagicMock()
+        mill.read = MagicMock(
+            return_value="<Idle|WPos:-100.500,-200.750,-50.250|FS:0,0>"
+        )
+
+        coords = mill.current_coordinates()
+
+        self.assertEqual(coords.x, -100.5)
+        self.assertEqual(coords.y, -200.75)
+        self.assertEqual(coords.z, -50.25)
+
+    def test_does_not_reference_config_10(self):
+        """current_coordinates should not branch on $10 since we enforce WPos."""
+        mill = self._make_mill()
+        mill.ser_mill.write = MagicMock()
+        mill.read = MagicMock(
+            return_value="<Idle|WPos:1.0,2.0,3.0|FS:0,0>"
+        )
+        # Even with $10=1, we should still parse WPos (because we enforce $10=0)
+        mill.config["$10"] = "1"
+
+        coords = mill.current_coordinates()
+
+        self.assertEqual(coords.x, 1.0)
+        self.assertEqual(coords.y, 2.0)
+        self.assertEqual(coords.z, 3.0)
+
+    def test_with_instrument_offset(self):
+        mill = self._make_mill()
+        mill.ser_mill.write = MagicMock()
+        mill.read = MagicMock(
+            return_value="<Idle|WPos:10.0,20.0,-5.0|FS:0,0>"
+        )
+        mill.instrument_manager.get_offset = MagicMock(
+            return_value=Coordinates(1.0, 2.0, 0.5)
+        )
+
+        instrument_coords = mill.current_coordinates(
+            instrument="pipette", instrument_only=True
+        )
+
+        self.assertEqual(instrument_coords.x, 9.0)
+        self.assertEqual(instrument_coords.y, 18.0)
+        self.assertEqual(instrument_coords.z, -5.5)
+
+
+class TestG90EnforcementOnConnect(unittest.TestCase):
+    """G90 (absolute positioning) must be enforced on connect."""
+
+    @patch("gantry.gantry_driver.driver.serial.Serial")
+    @patch("gantry.gantry_driver.driver.set_up_mill_logger")
+    @patch("gantry.gantry_driver.driver.set_up_command_logger")
+    def test_connect_enforces_absolute_positioning(
+        self, mock_cmd_logger, mock_mill_logger, mock_serial
+    ):
+        mock_serial_instance = MagicMock()
+        mock_serial_instance.is_open = True
+        mock_serial.return_value = mock_serial_instance
+
+        with patch.object(
+            Mill,
+            "locate_mill_over_serial",
+            return_value=(mock_serial_instance, "/dev/test"),
+        ):
+            mill = Mill()
+            mill.read_mill_config = MagicMock()
+            mill.write_mill_config_file = MagicMock()
+            mill.read_working_volume = MagicMock()
+            mill.check_for_alarm_state = MagicMock()
+            mill.clear_buffers = MagicMock()
+            mill.set_feed_rate = MagicMock()
+            mill.enforce_wpos_mode = MagicMock()
+            mill.enforce_absolute_positioning = MagicMock()
+
+            mill.connect_to_mill(port="/dev/test")
+
+            mill.enforce_absolute_positioning.assert_called_once()
+
+    @patch("gantry.gantry_driver.driver.serial.Serial")
+    @patch("gantry.gantry_driver.driver.set_up_mill_logger")
+    @patch("gantry.gantry_driver.driver.set_up_command_logger")
+    def test_enforce_absolute_positioning_sends_g90(
+        self, mock_cmd_logger, mock_mill_logger, mock_serial
+    ):
+        mill = Mill()
+        mill.ser_mill = MagicMock()
+        mill.execute_command = MagicMock()
+
+        mill.enforce_absolute_positioning()
+
+        mill.execute_command.assert_called_with("G90")
+
+
+class TestG90AfterHoming(unittest.TestCase):
+    """G90 must be enforced after both homing methods."""
+
+    @patch("gantry.gantry_driver.driver.serial.Serial")
+    @patch("gantry.gantry_driver.driver.set_up_mill_logger")
+    @patch("gantry.gantry_driver.driver.set_up_command_logger")
+    def test_home_enforces_g90_after_completion(
+        self, mock_cmd_logger, mock_mill_logger, mock_serial
+    ):
+        mill = Mill()
+        mill.ser_mill = MagicMock()
+        mill.execute_command = MagicMock()
+        mill.current_status = MagicMock(return_value="<Idle|WPos:0,0,0|FS:0,0>")
+
+        mill.home()
+
+        # G90 should be the last command sent
+        calls = mill.execute_command.call_args_list
+        self.assertEqual(calls[-1], call("G90"))
+
+
+class TestPostHomingCoordinateValidation(unittest.TestCase):
+    """After homing, WPos should be near the expected origin."""
+
+    @patch("gantry.gantry_driver.driver.serial.Serial")
+    @patch("gantry.gantry_driver.driver.set_up_mill_logger")
+    @patch("gantry.gantry_driver.driver.set_up_command_logger")
+    def _make_mill(self, mock_cmd_logger, mock_mill_logger, mock_serial):
+        mill = Mill()
+        mill.ser_mill = MagicMock()
+        return mill
+
+    def test_validate_post_homing_coordinates_passes_near_origin(self):
+        mill = self._make_mill()
+
+        coords = Coordinates(0.0, 0.0, -2.0)
+        # Should not raise
+        mill.validate_post_homing_coordinates(coords)
+
+    def test_validate_post_homing_coordinates_fails_on_wildly_off(self):
+        mill = self._make_mill()
+
+        coords = Coordinates(-300.0, -200.0, -50.0)
+        with self.assertRaises(StatusReturnError):
+            mill.validate_post_homing_coordinates(coords)
+
+    def test_homing_sequence_validates_coordinates(self):
+        mill = self._make_mill()
+        mill.home = MagicMock()
+        mill.set_feed_rate = MagicMock()
+        mill.clear_buffers = MagicMock()
+        mill.check_max_z_height = MagicMock()
+        mill.current_coordinates = MagicMock(
+            return_value=Coordinates(0.0, 0.0, 0.0)
+        )
+        mill.validate_post_homing_coordinates = MagicMock()
+
+        mill.homing_sequence()
+
+        mill.validate_post_homing_coordinates.assert_called_once()
+
+
+class TestMachineCoordinatesMethod(unittest.TestCase):
+    """machine_coordinates() should compute MPos from WPos + WCO."""
+
+    @patch("gantry.gantry_driver.driver.serial.Serial")
+    @patch("gantry.gantry_driver.driver.set_up_mill_logger")
+    @patch("gantry.gantry_driver.driver.set_up_command_logger")
+    def _make_mill(self, mock_cmd_logger, mock_mill_logger, mock_serial):
+        mill = Mill()
+        mill.ser_mill = MagicMock()
+        return mill
+
+    def test_machine_coordinates_with_zero_wco(self):
+        mill = self._make_mill()
+        mill.current_coordinates = MagicMock(
+            return_value=Coordinates(10.0, 20.0, -5.0)
+        )
+        mill._query_work_coordinate_offset = MagicMock(
+            return_value=Coordinates(0.0, 0.0, 0.0)
+        )
+
+        mpos = mill.machine_coordinates()
+
+        self.assertEqual(mpos.x, 10.0)
+        self.assertEqual(mpos.y, 20.0)
+        self.assertEqual(mpos.z, -5.0)
+
+    def test_machine_coordinates_with_nonzero_wco(self):
+        mill = self._make_mill()
+        mill.current_coordinates = MagicMock(
+            return_value=Coordinates(10.0, 20.0, -5.0)
+        )
+        mill._query_work_coordinate_offset = MagicMock(
+            return_value=Coordinates(-100.0, -50.0, -10.0)
+        )
+
+        mpos = mill.machine_coordinates()
+
+        # MPos = WPos + WCO
+        self.assertEqual(mpos.x, -90.0)
+        self.assertEqual(mpos.y, -30.0)
+        self.assertEqual(mpos.z, -15.0)
+
+    def test_query_work_coordinate_offset_parses_gcode_params(self):
+        mill = self._make_mill()
+        # $# returns lines like [G54:0.000,0.000,0.000] etc.
+        # WCO from a status with WCO: tag
+        mill.execute_command = MagicMock(return_value="[G54:-100.000,-50.000,-10.000]")
+
+        wco = mill._query_work_coordinate_offset()
+
+        self.assertEqual(wco.x, -100.0)
+        self.assertEqual(wco.y, -50.0)
+        self.assertEqual(wco.z, -10.0)
+
+
+class TestWPosPatternOnly(unittest.TestCase):
+    """Only wpos_pattern should be used; mpos_pattern should be removed."""
+
+    def test_wpos_pattern_matches_valid_status(self):
+        status = "<Idle|WPos:10.500,20.123,-5.000|FS:0,0>"
+        match = wpos_pattern.search(status)
+        self.assertIsNotNone(match)
+        self.assertEqual(match.group(1), "10.500")
+        self.assertEqual(match.group(2), "20.123")
+        self.assertEqual(match.group(3), "-5.000")
+
+    def test_wpos_pattern_does_not_match_mpos(self):
+        status = "<Idle|MPos:-400.123,-299.999,-10.000|FS:0,0>"
+        match = wpos_pattern.search(status)
+        self.assertIsNone(match)
+
+    def test_mpos_pattern_no_longer_exported(self):
+        """mpos_pattern should be removed from driver module."""
+        from gantry.gantry_driver import driver
+
+        self.assertFalse(hasattr(driver, "mpos_pattern"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
This PR eliminates a latent coordinate system mismatch in the driver by standardizing all coordinates to Work Position (WPos) exclusively. Previously, the driver could report Machine Position (MPos) via `$10=1` while commanding movement in WPos, creating a dangerous inconsistency that only worked by coincidence when no work offsets were set.

## Problem
- `current_coordinates()` could parse either MPos or WPos depending on `$10` setting
- All G-code movement commands (`G01`, `G00`) operate in WPos
- This mismatch would break if work offsets were set (e.g., via `G10 L20` in `home_xy_hard_limits()`)
- Dead code existed: unused `mpos_pattern`, unfinished `if coord_type == "MPos": pass`, and unused `homing_pull_off` variable

## Solution
Enforce WPos reporting and parsing throughout the system:

### Driver Changes (`src/gantry/gantry_driver/driver.py`)
- **Removed `mpos_pattern`** — only `wpos_pattern` remains for coordinate parsing
- **Added `enforce_wpos_mode()`** — sends `$10=0` during `connect_to_mill()` to force WPos reporting
- **Added `enforce_absolute_positioning()`** — sends `G90` during connect and after homing to prevent stale relative mode
- **Added `validate_post_homing_coordinates()`** — verifies WPos is within 10mm of origin after homing
- **Added `machine_coordinates()`** — diagnostic method to compute MPos = WPos + WCO (for debugging only)
- **Added `_query_work_coordinate_offset()`** — parses G54 offset from GRBL `$#` response
- **Simplified `current_coordinates()`** — removed `$10` branching, now only parses WPos; raises `LocationNotFound` if WPos not found
- **Updated `homing_sequence()`** — validates post-homing coordinates
- **Updated `home()`** — enforces G90 after homing completes

### Mock Changes (`src/gantry/gantry_driver/mock.py`)
- Changed all `MPos:` strings to `WPos:` in status responses to match enforced WPos reporting

### Test Changes
- Updated `tests/gantry/driver/test_gantry_driver.py` — removed MPos pattern tests, verified WPos-only behavior
- **New file: `tests/gantry/driver/test_coordinate_system.py`** — 21 comprehensive tests covering:
  - WPos enforcement on connect
  - WPos-only parsing with rejection of MPos
  - G90 enforcement on connect and after homing
  - Post-homing coordinate validation
  - Machine coordinate computation (WPos + WCO)
  - Pattern correctness and mpos_pattern removal

## Implementation Details
- `POST_HOMING_TOLERANCE = 10.0` mm per axis for post-homing validation
- `g54_pattern` added to parse G54 work coordinate offset from `$#` response
- All coordinate operations now assume WPos; MPos is only computed on-demand for diagnostics
- No changes to movement commands or instrument offset logic — they already use WPos correctly

## Test Results
- All 98 gantry tests pass (21 new + 77 existing)
- No regressions in existing functionality

https://claude.ai/code/session_01Sd1rJpXjY8JgUYvWYagdg7