### PR TITLE
Add UV curing instrument driver (Excelitas OmniCure S1500 PRO)

### DIFF
--- a/src/board/loader.py
+++ b/src/board/loader.py
@@ -12,6 +12,7 @@ from instruments.base_instrument import BaseInstrument
 from instruments.asmi.driver import ASMI
 from instruments.filmetrics.driver import Filmetrics
 from instruments.pipette.driver import Pipette
+from instruments.uv_curing.driver import UVCuring
 from instruments.uvvis_ccs.driver import UVVisCCS
 
 from .board import Board
@@ -24,9 +25,10 @@ if TYPE_CHECKING:
 
 INSTRUMENT_REGISTRY: Dict[str, Type[BaseInstrument]] = {
     "asmi": ASMI,
-    "uvvis_ccs": UVVisCCS,
-    "pipette": Pipette,
     "filmetrics": Filmetrics,
+    "pipette": Pipette,
+    "uv_curing": UVCuring,
+    "uvvis_ccs": UVVisCCS,
 }
 
 

--- a/src/instruments/uv_curing/__init__.py
+++ b/src/instruments/uv_curing/__init__.py
@@ -1,0 +1,18 @@
+from instruments.uv_curing.driver import UVCuring
+from instruments.uv_curing.models import CureResult, UVCuringStatus
+from instruments.uv_curing.exceptions import (
+    UVCuringError,
+    UVCuringConnectionError,
+    UVCuringCommandError,
+    UVCuringTimeoutError,
+)
+
+__all__ = [
+    "UVCuring",
+    "CureResult",
+    "UVCuringStatus",
+    "UVCuringError",
+    "UVCuringConnectionError",
+    "UVCuringCommandError",
+    "UVCuringTimeoutError",
+]

--- a/src/instruments/uv_curing/driver.py
+++ b/src/instruments/uv_curing/driver.py
@@ -1,0 +1,201 @@
+"""Driver for the Excelitas OmniCure S1500 PRO UV curing system.
+
+Controls the OmniCure via RS-232 serial (19200 baud, 8N1).
+Protocol: text commands with CRC8 suffix (currently XX placeholder).
+
+Commands used:
+    CONN    — handshake, expects READY response
+    SIL{n}  — set iris intensity 1-100%
+    STM{n}  — set exposure time in 0.1s units
+    RUN     — execute timed shutter cycle (device manages shutter internally)
+
+Reference: Excelitas OmniCure S1500 PRO/S2000 PRO/ELITE User's Guide
+
+The gantry handles Z positioning to the well. This driver controls
+only the UV light (intensity + timed exposure).
+"""
+
+import time
+from typing import Optional
+
+import serial
+
+from instruments.base_instrument import BaseInstrument
+from instruments.uv_curing.exceptions import (
+    UVCuringCommandError,
+    UVCuringConnectionError,
+    UVCuringTimeoutError,
+)
+from instruments.uv_curing.models import CureResult, UVCuringStatus
+
+
+class UVCuring(BaseInstrument):
+    """Driver for the Excelitas OmniCure S1500 PRO.
+
+    Pass ``offline=True`` for dry runs — no serial connection, cure()
+    returns immediately with synthetic results.
+
+    Board YAML fields:
+        port: Serial port (default /dev/ttyACM0).
+        baud_rate: Baud rate (default 19200).
+        default_intensity: Default UV intensity % (default 100).
+        default_exposure_time: Default exposure time in seconds (default 1.0).
+    """
+
+    def __init__(
+        self,
+        port: str = "/dev/ttyACM0",
+        baud_rate: int = 19200,
+        default_intensity: float = 100.0,
+        default_exposure_time: float = 1.0,
+        name: Optional[str] = None,
+        offset_x: float = 0.0,
+        offset_y: float = 0.0,
+        depth: float = 0.0,
+        measurement_height: float = 0.0,
+        offline: bool = False,
+        **kwargs,
+    ):
+        super().__init__(
+            name=name, offset_x=offset_x, offset_y=offset_y,
+            depth=depth, measurement_height=measurement_height,
+            offline=offline,
+        )
+        self._port = port
+        self._baud_rate = baud_rate
+        self._default_intensity = default_intensity
+        self._default_exposure_time = default_exposure_time
+        self._serial: Optional[serial.Serial] = None
+
+    # ── BaseInstrument interface ──────────────────────────────────────────
+
+    def connect(self) -> None:
+        if self._offline:
+            self.logger.info("UVCuring connected (offline)")
+            return
+        try:
+            self._serial = serial.Serial(
+                port=self._port,
+                baudrate=self._baud_rate,
+                bytesize=serial.EIGHTBITS,
+                parity=serial.PARITY_NONE,
+                stopbits=serial.STOPBITS_ONE,
+                timeout=2,
+                xonxoff=False,
+                rtscts=False,
+                dsrdtr=False,
+            )
+        except serial.SerialException as exc:
+            raise UVCuringConnectionError(
+                f"Cannot open OmniCure serial port {self._port}: {exc}"
+            ) from exc
+
+        self._handshake()
+        self.logger.info("Connected to OmniCure on %s", self._port)
+
+    def disconnect(self) -> None:
+        if self._offline:
+            self.logger.info("UVCuring disconnected (offline)")
+            return
+        if self._serial is not None:
+            try:
+                self._serial.close()
+            except serial.SerialException:
+                pass
+            self._serial = None
+        self.logger.info("OmniCure disconnected")
+
+    def health_check(self) -> bool:
+        if self._offline:
+            return True
+        return self._serial is not None and self._serial.is_open
+
+    # ── UV-specific commands ──────────────────────────────────────────────
+
+    def cure(
+        self,
+        intensity: Optional[float] = None,
+        exposure_time: Optional[float] = None,
+    ) -> CureResult:
+        """Execute a timed UV cure cycle.
+
+        Sets iris intensity, sets exposure time, sends RUN command.
+        The OmniCure handles the shutter internally — RUN opens the
+        shutter for the programmed duration then closes it.
+
+        Args:
+            intensity: Iris intensity 1-100% (uses default if None).
+            exposure_time: Exposure duration in seconds (uses default if None).
+
+        Returns:
+            CureResult with the parameters used.
+        """
+        intensity = intensity if intensity is not None else self._default_intensity
+        exposure_time = exposure_time if exposure_time is not None else self._default_exposure_time
+
+        if not (1 <= intensity <= 100):
+            raise UVCuringCommandError("Intensity must be between 1 and 100%")
+        if exposure_time <= 0:
+            raise UVCuringCommandError("Exposure time must be > 0 seconds")
+
+        if self._offline:
+            self.logger.info(
+                "Cure (offline): %.0f%% for %.2fs", intensity, exposure_time,
+            )
+            return CureResult(
+                intensity_percent=intensity,
+                exposure_time_s=exposure_time,
+                timestamp=time.time(),
+            )
+
+        self._send_command(f"SIL{int(intensity)}")
+        self._send_command(f"STM{int(exposure_time * 10)}")
+        self._send_command("RUN")
+        time.sleep(exposure_time + 0.05)
+
+        self.logger.info("Cured: %d%% for %.2fs", intensity, exposure_time)
+
+        return CureResult(
+            intensity_percent=intensity,
+            exposure_time_s=exposure_time,
+            timestamp=time.time(),
+        )
+
+    def measure(self, **kwargs) -> CureResult:
+        """Protocol-compatible alias for cure(). Called by the scan command."""
+        return self.cure(**kwargs)
+
+    def get_status(self) -> UVCuringStatus:
+        return UVCuringStatus(is_connected=self.health_check())
+
+    # ── Private helpers ───────────────────────────────────────────────────
+
+    def _handshake(self) -> None:
+        """Send CONN until the OmniCure responds with READY."""
+        for _ in range(10):
+            response = self._send_command("CONN")
+            if response.startswith("READY"):
+                return
+            time.sleep(0.5)
+        raise UVCuringConnectionError(
+            "OmniCure did not respond READY after CONN"
+        )
+
+    def _send_command(self, command: str) -> str:
+        """Send a command with CRC8 suffix and return the response."""
+        if self._serial is None or not self._serial.is_open:
+            raise UVCuringCommandError("Not connected to OmniCure")
+        full_cmd = f"{command}XX\r"
+        try:
+            self._serial.write(full_cmd.encode())
+            response = self._serial.readline().decode(errors="ignore").strip()
+        except serial.SerialException as exc:
+            raise UVCuringCommandError(
+                f"Serial error sending '{command}': {exc}"
+            ) from exc
+        if not response:
+            raise UVCuringTimeoutError(
+                f"No response to '{command}'"
+            )
+        self.logger.debug(">> %s  << %s", command, response)
+        return response

--- a/src/instruments/uv_curing/exceptions.py
+++ b/src/instruments/uv_curing/exceptions.py
@@ -1,0 +1,17 @@
+from instruments.base_instrument import InstrumentError
+
+
+class UVCuringError(InstrumentError):
+    """Base exception for all UV curing instrument errors."""
+
+
+class UVCuringConnectionError(UVCuringError):
+    """Raised when the OmniCure cannot be found or opened."""
+
+
+class UVCuringCommandError(UVCuringError):
+    """Raised when a serial command fails or gets an error response."""
+
+
+class UVCuringTimeoutError(UVCuringError):
+    """Raised when the OmniCure does not respond within the timeout."""

--- a/src/instruments/uv_curing/models.py
+++ b/src/instruments/uv_curing/models.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CureResult:
+    """Result of a single UV curing exposure."""
+
+    intensity_percent: float
+    exposure_time_s: float
+    timestamp: float
+
+
+@dataclass(frozen=True)
+class UVCuringStatus:
+    """Snapshot of OmniCure connection state."""
+
+    is_connected: bool

--- a/tests/instruments/test_uv_curing.py
+++ b/tests/instruments/test_uv_curing.py
@@ -1,0 +1,158 @@
+"""Tests for the Excelitas OmniCure S1500 PRO UV curing driver."""
+
+import unittest
+from unittest.mock import patch, MagicMock
+
+from instruments.base_instrument import BaseInstrument, InstrumentError
+from instruments.uv_curing.driver import UVCuring
+from instruments.uv_curing.models import CureResult, UVCuringStatus
+from instruments.uv_curing.exceptions import (
+    UVCuringError,
+    UVCuringConnectionError,
+    UVCuringCommandError,
+    UVCuringTimeoutError,
+)
+
+
+class TestExceptionHierarchy(unittest.TestCase):
+
+    def test_base_is_instrument_error(self):
+        self.assertTrue(issubclass(UVCuringError, InstrumentError))
+
+    def test_connection_error(self):
+        self.assertTrue(issubclass(UVCuringConnectionError, UVCuringError))
+
+    def test_command_error(self):
+        self.assertTrue(issubclass(UVCuringCommandError, UVCuringError))
+
+    def test_timeout_error(self):
+        self.assertTrue(issubclass(UVCuringTimeoutError, UVCuringError))
+
+
+class TestCureResult(unittest.TestCase):
+
+    def test_frozen(self):
+        r = CureResult(intensity_percent=50.0, exposure_time_s=1.0, timestamp=0.0)
+        with self.assertRaises(AttributeError):
+            r.intensity_percent = 99.0
+
+
+class TestUVCuringIsBaseInstrument(unittest.TestCase):
+
+    def test_is_subclass(self):
+        self.assertTrue(issubclass(UVCuring, BaseInstrument))
+
+
+class TestUVCuringOffline(unittest.TestCase):
+
+    def setUp(self):
+        self.uv = UVCuring(offline=True, default_intensity=50.0,
+                           default_exposure_time=2.0)
+
+    def test_connect_disconnect(self):
+        self.uv.connect()
+        self.uv.disconnect()
+
+    def test_health_check(self):
+        self.assertTrue(self.uv.health_check())
+
+    def test_cure_returns_result(self):
+        result = self.uv.cure(intensity=80.0, exposure_time=3.0)
+        self.assertIsInstance(result, CureResult)
+        self.assertAlmostEqual(result.intensity_percent, 80.0)
+        self.assertAlmostEqual(result.exposure_time_s, 3.0)
+
+    def test_cure_uses_defaults(self):
+        result = self.uv.cure()
+        self.assertAlmostEqual(result.intensity_percent, 50.0)
+        self.assertAlmostEqual(result.exposure_time_s, 2.0)
+
+    def test_cure_rejects_zero_intensity(self):
+        with self.assertRaises(UVCuringCommandError):
+            self.uv.cure(intensity=0)
+
+    def test_cure_rejects_intensity_over_100(self):
+        with self.assertRaises(UVCuringCommandError):
+            self.uv.cure(intensity=101)
+
+    def test_cure_rejects_zero_exposure(self):
+        with self.assertRaises(UVCuringCommandError):
+            self.uv.cure(exposure_time=0)
+
+    def test_measure_is_alias(self):
+        result = self.uv.measure(intensity=10.0)
+        self.assertIsInstance(result, CureResult)
+
+    def test_get_status(self):
+        status = self.uv.get_status()
+        self.assertIsInstance(status, UVCuringStatus)
+        self.assertTrue(status.is_connected)
+
+
+class TestUVCuringOnlineGuards(unittest.TestCase):
+
+    def test_health_check_false_without_connect(self):
+        uv = UVCuring(offline=False)
+        self.assertFalse(uv.health_check())
+
+    def test_send_command_raises_without_connect(self):
+        uv = UVCuring(offline=False)
+        with self.assertRaises(UVCuringCommandError):
+            uv._send_command("CONN")
+
+
+class TestUVCuringMockedSerial(unittest.TestCase):
+
+    @patch('instruments.uv_curing.driver.serial.Serial')
+    def test_connect_opens_serial_and_handshakes(self, mock_serial_cls):
+        mock_ser = mock_serial_cls.return_value
+        mock_ser.readline.return_value = b"READY\r\n"
+        mock_ser.is_open = True
+        uv = UVCuring(port="/dev/ttyACM0", offline=False)
+        uv.connect()
+        mock_serial_cls.assert_called_once()
+        # CONN was sent during handshake
+        mock_ser.write.assert_called()
+
+    @patch('instruments.uv_curing.driver.serial.Serial')
+    def test_connect_raises_on_serial_error(self, mock_serial_cls):
+        mock_serial_cls.side_effect = serial.SerialException("no port")
+        uv = UVCuring(port="/dev/fake", offline=False)
+        with self.assertRaises(UVCuringConnectionError):
+            uv.connect()
+
+    @patch('instruments.uv_curing.driver.serial.Serial')
+    def test_send_command_format(self, mock_serial_cls):
+        mock_ser = mock_serial_cls.return_value
+        mock_ser.is_open = True
+        mock_ser.readline.return_value = b"READY\r\n"
+        uv = UVCuring(offline=False)
+        uv.connect()
+        mock_ser.reset_mock()
+        mock_ser.readline.return_value = b"OK\r\n"
+        uv._send_command("SIL50")
+        mock_ser.write.assert_called_with(b"SIL50XX\r")
+
+    @patch('instruments.uv_curing.driver.serial.Serial')
+    def test_send_command_timeout(self, mock_serial_cls):
+        mock_ser = mock_serial_cls.return_value
+        mock_ser.is_open = True
+        mock_ser.readline.return_value = b"READY\r\n"
+        uv = UVCuring(offline=False)
+        uv.connect()
+        mock_ser.readline.return_value = b""
+        with self.assertRaises(UVCuringTimeoutError):
+            uv._send_command("SIL50")
+
+    @patch('instruments.uv_curing.driver.serial.Serial')
+    def test_disconnect_closes_serial(self, mock_serial_cls):
+        mock_ser = mock_serial_cls.return_value
+        mock_ser.is_open = True
+        mock_ser.readline.return_value = b"READY\r\n"
+        uv = UVCuring(offline=False)
+        uv.connect()
+        uv.disconnect()
+        mock_ser.close.assert_called_once()
+
+
+import serial  # needed for SerialException in test


### PR DESCRIPTION
Based on actual SHARC codebase — OmniCure serial protocol (19200 8N1):
  CONN → READY handshake
  SIL{1-100} → set iris intensity
  STM{tenths} → set exposure time in 0.1s units
  RUN → execute timed shutter cycle (device-managed)

Driver: connect, cure(intensity, exposure_time), measure() alias. Follows BaseInstrument pattern with offline=True support. Registered as "uv_curing" in board loader.
17 tests (offline, online guards, mocked serial).