### PR TITLE
[codex] Add ASMI SQLite read helpers

### DIFF
--- a/data/analysis/asmi.py
+++ b/data/analysis/asmi.py
@@ -1,0 +1,153 @@
+"""ASMI-specific data retrieval helpers.
+
+Operates on the ``asmi_measurements`` SQLite table. Provides BLOB unpacking,
+typed records, and convenience loaders for experiment/campaign/well access.
+"""
+
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass
+from typing import List, Optional
+
+from data.data_reader import DataReader
+
+
+@dataclass(frozen=True)
+class ASMIRecord:
+    """Unpacked ASMI indentation measurement with metadata."""
+
+    measurement_id: int
+    experiment_id: int
+    z_positions: tuple[float, ...]
+    raw_forces: tuple[float, ...]
+    corrected_forces: tuple[float, ...]
+    baseline_avg: float
+    baseline_std: float
+    force_exceeded: bool
+    data_points: int
+    step_size_mm: Optional[float] = None
+    z_target_mm: Optional[float] = None
+    force_limit_n: Optional[float] = None
+    timestamp: Optional[str] = None
+    well_id: Optional[str] = None
+    labware_name: Optional[str] = None
+
+
+def _unpack_floats(blob: bytes) -> tuple[float, ...]:
+    """Unpack a little-endian float64 BLOB into a tuple of floats."""
+    if len(blob) == 0:
+        return ()
+    count = len(blob) // 8
+    return struct.unpack(f"<{count}d", blob)
+
+
+def unpack_asmi_measurement(
+    *,
+    z_positions_blob: bytes,
+    raw_forces_blob: bytes,
+    corrected_forces_blob: bytes,
+    baseline_avg: float,
+    baseline_std: float,
+    force_exceeded: bool | int,
+    data_points: int,
+    experiment_id: int,
+    measurement_id: int,
+    step_size_mm: Optional[float] = None,
+    z_target_mm: Optional[float] = None,
+    force_limit_n: Optional[float] = None,
+    timestamp: Optional[str] = None,
+    well_id: Optional[str] = None,
+    labware_name: Optional[str] = None,
+) -> ASMIRecord:
+    """Unpack raw DB fields into an :class:`ASMIRecord`."""
+    return ASMIRecord(
+        measurement_id=measurement_id,
+        experiment_id=experiment_id,
+        z_positions=_unpack_floats(z_positions_blob),
+        raw_forces=_unpack_floats(raw_forces_blob),
+        corrected_forces=_unpack_floats(corrected_forces_blob),
+        baseline_avg=baseline_avg,
+        baseline_std=baseline_std,
+        force_exceeded=bool(force_exceeded),
+        data_points=data_points,
+        step_size_mm=step_size_mm,
+        z_target_mm=z_target_mm,
+        force_limit_n=force_limit_n,
+        timestamp=timestamp,
+        well_id=well_id,
+        labware_name=labware_name,
+    )
+
+
+def load_asmi_by_experiment(
+    reader: DataReader,
+    experiment_id: int,
+) -> List[ASMIRecord]:
+    """Load all ASMI measurements for a given experiment."""
+    rows = reader.get_measurements(experiment_id, table="asmi_measurements")
+    return [
+        unpack_asmi_measurement(
+            z_positions_blob=row["z_positions"],
+            raw_forces_blob=row["raw_forces"],
+            corrected_forces_blob=row["corrected_forces"],
+            baseline_avg=row["baseline_avg"],
+            baseline_std=row["baseline_std"],
+            force_exceeded=row["force_exceeded"],
+            data_points=row["data_points"],
+            step_size_mm=row.get("step_size_mm"),
+            z_target_mm=row.get("z_target_mm"),
+            force_limit_n=row.get("force_limit_n"),
+            timestamp=row.get("timestamp"),
+            experiment_id=row["experiment_id"],
+            measurement_id=row["id"],
+        )
+        for row in rows
+    ]
+
+
+def load_asmi_by_campaign(
+    reader: DataReader,
+    campaign_id: int,
+) -> List[ASMIRecord]:
+    """Load all ASMI measurements for a campaign, with well/labware metadata."""
+    rows = reader.get_measurements_by_campaign(
+        campaign_id,
+        table="asmi_measurements",
+    )
+    return [
+        unpack_asmi_measurement(
+            z_positions_blob=row["z_positions"],
+            raw_forces_blob=row["raw_forces"],
+            corrected_forces_blob=row["corrected_forces"],
+            baseline_avg=row["baseline_avg"],
+            baseline_std=row["baseline_std"],
+            force_exceeded=row["force_exceeded"],
+            data_points=row["data_points"],
+            step_size_mm=row.get("step_size_mm"),
+            z_target_mm=row.get("z_target_mm"),
+            force_limit_n=row.get("force_limit_n"),
+            timestamp=row.get("timestamp"),
+            experiment_id=row["experiment_id"],
+            measurement_id=row["id"],
+            well_id=row.get("well_id"),
+            labware_name=row.get("labware_name"),
+        )
+        for row in rows
+    ]
+
+
+def load_asmi_by_well(
+    reader: DataReader,
+    campaign_id: int,
+    well_id: str,
+    labware_name: Optional[str] = None,
+) -> List[ASMIRecord]:
+    """Load ASMI measurements for one well within a campaign."""
+    target_well = well_id.upper()
+    records = load_asmi_by_campaign(reader, campaign_id=campaign_id)
+    return [
+        record for record in records
+        if record.well_id == target_well
+        and (labware_name is None or record.labware_name == labware_name)
+    ]

--- a/data/data_reader.py
+++ b/data/data_reader.py
@@ -14,6 +14,7 @@ _VALID_MEASUREMENT_TABLES = frozenset({
     "uvvis_measurements",
     "filmetrics_measurements",
     "camera_measurements",
+    "asmi_measurements",
 })
 
 

--- a/tests/data/test_asmi_analysis.py
+++ b/tests/data/test_asmi_analysis.py
@@ -1,0 +1,136 @@
+"""Tests for ASMI SQL read/unpack helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from data.analysis.asmi import (
+    ASMIRecord,
+    load_asmi_by_campaign,
+    load_asmi_by_experiment,
+    load_asmi_by_well,
+    unpack_asmi_measurement,
+)
+from data.data_reader import DataReader
+from data.data_store import DataStore
+from protocol_engine.measurements import InstrumentMeasurement, MeasurementType
+
+
+def _seed_asmi_store() -> DataStore:
+    store = DataStore(db_path=":memory:")
+    campaign_id = store.create_campaign(description="asmi test")
+    exp_a1 = store.create_experiment(campaign_id, "plate_1", "A1", "[]")
+    exp_b2 = store.create_experiment(campaign_id, "plate_1", "B2", "[]")
+
+    first = InstrumentMeasurement(
+        measurement_type=MeasurementType.ASMI_INDENTATION,
+        payload={
+            "z_positions_mm": [0.0, -0.1, -0.2],
+            "raw_forces_n": [0.01, 0.04, 0.08],
+            "corrected_forces_n": [0.0, 0.03, 0.07],
+        },
+        metadata={
+            "baseline_avg": 0.01,
+            "baseline_std": 0.002,
+            "force_exceeded": False,
+            "data_points": 3,
+        },
+    )
+    second = InstrumentMeasurement(
+        measurement_type=MeasurementType.ASMI_INDENTATION,
+        payload={
+            "z_positions_mm": [0.0, -0.2, -0.4],
+            "raw_forces_n": [0.02, 0.08, 0.16],
+            "corrected_forces_n": [0.0, 0.06, 0.14],
+        },
+        metadata={
+            "baseline_avg": 0.02,
+            "baseline_std": 0.003,
+            "force_exceeded": True,
+            "data_points": 3,
+        },
+    )
+
+    measurement_a1 = store.log_measurement(exp_a1, first)
+    measurement_b2 = store.log_measurement(exp_b2, second)
+    store._conn.execute(
+        "UPDATE asmi_measurements "
+        "SET step_size_mm = ?, z_target_mm = ?, force_limit_n = ? "
+        "WHERE id = ?",
+        (0.01, -1.5, 0.25, measurement_a1),
+    )
+    store._conn.execute(
+        "UPDATE asmi_measurements "
+        "SET step_size_mm = ?, z_target_mm = ?, force_limit_n = ? "
+        "WHERE id = ?",
+        (0.02, -2.0, 0.50, measurement_b2),
+    )
+    store._conn.commit()
+    return store
+
+
+@pytest.fixture()
+def seeded_reader() -> DataReader:
+    store = _seed_asmi_store()
+    reader = DataReader(connection=store._conn)
+    yield reader
+    store.close()
+
+
+class TestUnpackASMIMeasurement:
+
+    def test_unpacks_blob_fields_and_metadata(self, seeded_reader: DataReader):
+        row = seeded_reader.get_measurements(1, table="asmi_measurements")[0]
+
+        record = unpack_asmi_measurement(
+            z_positions_blob=row["z_positions"],
+            raw_forces_blob=row["raw_forces"],
+            corrected_forces_blob=row["corrected_forces"],
+            baseline_avg=row["baseline_avg"],
+            baseline_std=row["baseline_std"],
+            force_exceeded=row["force_exceeded"],
+            data_points=row["data_points"],
+            step_size_mm=row["step_size_mm"],
+            z_target_mm=row["z_target_mm"],
+            force_limit_n=row["force_limit_n"],
+            timestamp=row["timestamp"],
+            experiment_id=row["experiment_id"],
+            measurement_id=row["id"],
+        )
+
+        assert isinstance(record, ASMIRecord)
+        assert record.z_positions == (0.0, -0.1, -0.2)
+        assert record.raw_forces == (0.01, 0.04, 0.08)
+        assert record.corrected_forces == (0.0, 0.03, 0.07)
+        assert record.baseline_avg == pytest.approx(0.01)
+        assert record.baseline_std == pytest.approx(0.002)
+        assert record.force_exceeded is False
+        assert record.step_size_mm == pytest.approx(0.01)
+        assert record.z_target_mm == pytest.approx(-1.5)
+        assert record.force_limit_n == pytest.approx(0.25)
+
+
+class TestLoadASMI:
+
+    def test_load_by_experiment(self, seeded_reader: DataReader):
+        records = load_asmi_by_experiment(seeded_reader, experiment_id=1)
+        assert len(records) == 1
+        assert records[0].experiment_id == 1
+        assert records[0].timestamp is not None
+
+    def test_load_by_campaign(self, seeded_reader: DataReader):
+        records = load_asmi_by_campaign(seeded_reader, campaign_id=1)
+        assert len(records) == 2
+        assert {record.well_id for record in records} == {"A1", "B2"}
+        assert {record.labware_name for record in records} == {"plate_1"}
+
+    def test_load_by_well(self, seeded_reader: DataReader):
+        records = load_asmi_by_well(seeded_reader, campaign_id=1, well_id="b2")
+        assert len(records) == 1
+        assert records[0].well_id == "B2"
+        assert records[0].force_exceeded is True
+
+    def test_load_empty_results(self, seeded_reader: DataReader):
+        assert load_asmi_by_experiment(seeded_reader, experiment_id=999) == []
+        assert load_asmi_by_campaign(seeded_reader, campaign_id=999) == []
+        assert load_asmi_by_well(seeded_reader, campaign_id=1, well_id="H12") == []


### PR DESCRIPTION
## What changed
- added `data/analysis/asmi.py` with typed ASMI read/unpack helpers
- allowed `asmi_measurements` in `data/data_reader.py`
- added regression tests for ASMI experiment/campaign/well reads

## Why it changed
PANDA already stores ASMI traces in SQLite, but there was no simple read-side helper layer for loading them from Python without pulling in analysis or plotting code.

## User / developer impact
Developers can now load ASMI measurements by experiment, campaign, or well through a small PANDA-native helper API.

## Root cause
The repo had ASMI write-side persistence but lacked corresponding read/unpack convenience helpers.

## Validation
- `python -m pytest tests/data/test_asmi_analysis.py tests/data/test_data_reader.py tests/data/test_uvvis_analysis.py -q`
- `python -m py_compile data/data_reader.py data/analysis/asmi.py tests/data/test_asmi_analysis.py`