### PR TITLE
[codex] add hello_world regression test for renamed gantry configs

### DIFF
--- a/setup/hello_world.py
+++ b/setup/hello_world.py
@@ -24,11 +24,11 @@ CONFIGS_DIR = project_root / "configs"
 GANTRIES = {
     "CUB_XL": {
         "label": "Cub-XL (415x300x200mm)",
-        "config_file": CONFIGS_DIR / "gantries" / "cubos_xl.yaml",
+        "config_file": CONFIGS_DIR / "gantry" / "cubos_xl.yaml",
     },
     "CUB": {
         "label": "Cub (300x200x80mm)",
-        "config_file": CONFIGS_DIR / "gantries" / "cubos.yaml",
+        "config_file": CONFIGS_DIR / "gantry" / "cubos.yaml",
     },
 }
 

--- a/tests/setup/test_hello_world.py
+++ b/tests/setup/test_hello_world.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from setup import hello_world
+
+
+@pytest.mark.parametrize(
+    ("user_choice", "gantry_key", "expected_bounds"),
+    [
+        ("1", "CUB_XL", (400.0, 300.0, 80.0)),
+        ("2", "CUB", (300.0, 200.0, 80.0)),
+    ],
+)
+def test_select_gantry_loads_renamed_config_files(
+    monkeypatch: pytest.MonkeyPatch,
+    user_choice: str,
+    gantry_key: str,
+    expected_bounds: tuple[float, float, float],
+) -> None:
+    monkeypatch.setattr("builtins.input", lambda _: user_choice)
+
+    gantry_entry, config = hello_world.select_gantry()
+
+    assert gantry_entry == hello_world.GANTRIES[gantry_key]
+    assert Path(gantry_entry["config_file"]).is_file()
+    assert config["working_volume"]["x_max"] == expected_bounds[0]
+    assert config["working_volume"]["y_max"] == expected_bounds[1]
+    assert config["working_volume"]["z_max"] == expected_bounds[2]


### PR DESCRIPTION
## What changed
- fixed `setup/hello_world.py` to load gantry configs from `configs/gantry/`
- added a focused regression test covering both renamed config choices in the interactive selector

## Why
The recent gantry config rename removed `configs/gantries/*`, but the first-run setup script still referenced the old directory. That path was untested, so the script would fail before hardware setup began.

## Impact
The interactive hello-world flow can now load the shipped Cub and Cub-XL configs again, and future config-path regressions in this script will fail in tests.

## Validation
- `pytest -q tests/setup/test_hello_world.py tests/setup/test_setup_imports.py tests/setup/test_protocol_setup.py`

## Root cause
A setup script path map was not updated when gantry configs were renamed and moved to the singular `configs/gantry/` directory.