### PR TITLE
Update Read the Docs configuration docs

### DIFF
--- a/docs/board.md
+++ b/docs/board.md
@@ -10,6 +10,7 @@ Representative example:
 instruments:
   asmi:
     type: asmi
+    vendor: vernier
     offset_x: 0.0
     offset_y: 0.0
     depth: 0.0
@@ -24,9 +25,24 @@ Use this file when:
 - offsets or reach depths change
 - instrument-specific connection settings change
 
+## Schema
+
+The top-level YAML key is `instruments`. Each instrument entry requires:
+
+- `type` - instrument type key from the registry
+- `vendor` - allowed vendor for that type
+
+Common optional fields are:
+
+- `offset_x` and `offset_y` - XY offset from the gantry head reference point
+- `depth` - Z offset from the gantry head reference point
+- `measurement_height` - instrument-specific height offset used by measurement commands
+
+Driver-specific fields, such as serial ports, DLL paths, pipette models, or sensor channels, are passed through to the instrument driver constructor. Unknown top-level keys are rejected.
+
 ## Supported Instruments
 
-All instruments have real drivers and mock variants for offline testing.
+The board loader validates each `type` and `vendor` against the instrument registry, then instantiates the matching driver. Offline validation can pass `mock_mode=True`, which creates the configured drivers with `offline=True`.
 
 | Instrument | Type Key | Vendor | Description |
 |------------|----------|--------|-------------|

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,7 +17,9 @@ configs/
 Gantry YAML defines:
 
 - serial port
-- homing strategy
+- CNC homing strategy
+- total Z reference height
+- Y-axis motion mode
 - working volume
 - optional GRBL settings expectations
 
@@ -27,6 +29,8 @@ Representative example:
 serial_port: /dev/cu.usbserial-140
 cnc:
   homing_strategy: xy_hard_limits
+  total_z_height: 90.0
+  y_axis_motion: head
 
 working_volume:
   x_min: 0.0
@@ -89,6 +93,7 @@ Representative example:
 instruments:
   uvvis:
     type: uvvis_ccs
+    vendor: thorlabs
     serial_number: "M00801544"
     dll_path: "TLCCS_64.dll"
     default_integration_time_s: 0.24
@@ -117,6 +122,7 @@ protocol:
       position: plate_1.A1
   - measure:
       instrument: uvvis
+      position: plate_1.A1
 ```
 
 Use this file when:

--- a/docs/deck.md
+++ b/docs/deck.md
@@ -27,6 +27,21 @@ Use this file when:
 - the physical deck arrangement changes
 - a different plate or vial layout is installed
 
+## Z Coordinates
+
+Labware positions can define Z in either of two ways:
+
+- Provide explicit `z` values on calibration or location points.
+- Provide `height` on the labware entry and load the deck with the gantry `total_z_height`; CubOS computes Z as `total_z_height - height`.
+
+If `height` is used, `total_z_height` must be available from the gantry config. If `height` is not used, explicit Z coordinates are required.
+
+## Well Plate Calibration
+
+For well plates, `calibration.a1` is the A1 well center and `calibration.a2` must be one adjacent column step from A1. A2 must share either the same X or the same Y as A1, and its delta must match either `x_offset_mm` or `y_offset_mm` depending on the plate orientation. Diagonal calibration is rejected.
+
+Top-level `a1` is still accepted for backward compatibility, but new deck files should use `calibration.a1`.
+
 ## Labware Types
 
 - **Well plates** — defined by rows, columns, and two-point calibration. Positions are referenced by well ID (e.g. `plate.A1`).

--- a/docs/gantry.md
+++ b/docs/gantry.md
@@ -72,6 +72,3 @@ Working volume bounds are inclusive. Current configs include both positive-space
 |--------|--------|----------------|
 | `cubos_xl.yaml` | CubOS-XL / Genmitsu 3018 PRO | 400 x 300 x 80 mm |
 | `cubos.yaml` | CubOS / Genmitsu 3018 PROVer V2 | 300 x 200 x 80 mm |
-| `genmitsu_3018_PROver_v2.yaml` | PANDA / Genmitsu 3018 PROVer V2 | 300 x 200 x 80 mm |
-| `genmitsu_3018_PRO_Desktop.yaml` | CUB / Genmitsu 3018 PRO Desktop | 281 x 181 x 80 mm |
-| `asmi_gantry.yaml` | ASMI / Genmitsu 3018 PRO | negative-space 400 x 300 x 80 mm |

--- a/docs/gantry.md
+++ b/docs/gantry.md
@@ -7,7 +7,9 @@ The gantry is the CNC motion platform that moves instruments over the deck. CubO
 Gantry YAML defines:
 
 - serial port
-- homing strategy
+- CNC homing strategy
+- total Z reference height
+- Y-axis motion mode
 - working volume
 - optional GRBL settings expectations
 
@@ -16,18 +18,25 @@ Representative example:
 ```yaml
 serial_port: /dev/ttyUSB0
 cnc:
-  homing_strategy: standard
+  homing_strategy: xy_hard_limits
+  total_z_height: 90.0
+  y_axis_motion: head
 
 working_volume:
-  x_min: -400.0
-  x_max: 0.01
-  y_min: -300.0
-  y_max: 0.01
-  z_min: -80.0
-  z_max: 0.0
+  x_min: 0.0
+  x_max: 300.0
+  y_min: 0.0
+  y_max: 200.0
+  z_min: 0.0
+  z_max: 80.0
 
 grbl_settings:
+  dir_invert_mask: 2
+  status_report: 0
+  hard_limits: true
   homing_enable: true
+  homing_dir_mask: 3
+  homing_pull_off: 2.0
   steps_per_mm_x: 800.0
   steps_per_mm_y: 800.0
   steps_per_mm_z: 800.0
@@ -43,9 +52,26 @@ Use this file when:
 - updating homing behavior
 - validating expected controller settings
 
+## CNC Fields
+
+`homing_strategy` must be one of:
+
+- `xy_hard_limits`
+- `standard`
+- `manual_origin`
+
+`total_z_height` is required and must be greater than zero. Deck labware can use a `height` field instead of explicit Z coordinates; in that case CubOS computes user-space Z as `total_z_height - height`.
+
+`y_axis_motion` is optional and defaults to `head`. Use `head` when the gantry head moves along Y, and `bed` when the machine bed moves along Y.
+
+Working volume bounds are inclusive. Current configs include both positive-space gantries and the older ASMI negative-space gantry, so match the coordinate convention used by your selected gantry config.
+
 ## Supported Gantries
 
 | Config | System | Working Volume |
 |--------|--------|----------------|
-| `cubos_xl.yaml` | Cub-XL | 300 x 200 x 80 mm |
-| `cubos.yaml` | Cub | 300 x 200 x 80 mm |
+| `cubos_xl.yaml` | CubOS-XL / Genmitsu 3018 PRO | 400 x 300 x 80 mm |
+| `cubos.yaml` | CubOS / Genmitsu 3018 PROVer V2 | 300 x 200 x 80 mm |
+| `genmitsu_3018_PROver_v2.yaml` | PANDA / Genmitsu 3018 PROVer V2 | 300 x 200 x 80 mm |
+| `genmitsu_3018_PRO_Desktop.yaml` | CUB / Genmitsu 3018 PRO Desktop | 281 x 181 x 80 mm |
+| `asmi_gantry.yaml` | ASMI / Genmitsu 3018 PRO | negative-space 400 x 300 x 80 mm |

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -55,10 +55,9 @@ Use this file when:
 |---------|-------------|
 | `move` | Move an instrument to a deck position |
 | `scan` | Iterate all wells on a plate, calling an instrument method per well |
-| `measure` | Single measurement with an instrument |
+| `measure` | Move to one deck position, then call an instrument method |
 | `pick_up_tip` | Pipette: pick up a tip |
 | `aspirate` | Pipette: draw liquid |
-| `dispense` | Pipette: deliver liquid |
 | `transfer` | Pipette: combined move + aspirate + move + dispense |
 | `serial_transfer` | Pipette: sequential transfers across positions |
 | `mix` | Pipette: aspirate/dispense repeatedly |
@@ -67,6 +66,28 @@ Use this file when:
 | `home` | Home the gantry |
 | `pause` | Pause execution for N seconds |
 | `breakpoint` | Debug pause with user prompt |
+
+`dispense` exists as an internal helper used by `transfer`, but it is not currently registered as a YAML protocol command.
+
+## Position Values
+
+The `move` command accepts:
+
+- a named position from the top-level `positions` mapping
+- raw `[x, y, z]` coordinates
+- a deck target string such as `plate_1.A1` or `vial_1`
+
+The `measure` command requires both `instrument` and `position`. It resolves the deck target, applies the instrument's `measurement_height`, moves there, and then calls the selected method. The default method is `measure`.
+
+Example:
+
+```yaml
+protocol:
+  - measure:
+      instrument: uvvis
+      position: plate_1.A1
+      method: measure
+```
 
 ## Where Commands Live
 


### PR DESCRIPTION
## Summary
- Document current gantry YAML fields, including `total_z_height`, `y_axis_motion`, homing strategies, and supported gantry volumes.
- Clarify board YAML requirements for `vendor`, common offset fields, and driver-specific passthrough settings.
- Add deck guidance for height-derived Z coordinates and well-plate calibration rules.
- Correct protocol docs for `measure` position handling and remove `dispense` from registered YAML commands.

## Testing
- `python -m mkdocs build`