### PR TITLE
Fix tip rack loader to forward YAML dimension fields

### DIFF
--- a/src/deck/loader.py
+++ b/src/deck/loader.py
@@ -215,18 +215,14 @@ def _build_tip_rack(
     else:
         loc = tips["A1"]
 
-    return TipRack(
-        name=entry.name,
-        model_name=entry.model_name,
+    kwargs = _entry_kwargs_for_model(entry, TipRack)
+    kwargs.update(
         location=loc,
-        rows=entry.rows,
-        columns=entry.columns,
-        z_pickup=entry.z_pickup,
-        z_drop=entry.z_drop,
         tips=tips,
         tip_present=dict(entry.tip_present),
         slots=_build_holder_slots(entry.slots, default_z=loc.z),
     )
+    return TipRack(**kwargs)
 
 
 def _row_labels(rows: int) -> list[str]:

--- a/tests/test_deck_loader.py
+++ b/tests/test_deck_loader.py
@@ -7,7 +7,7 @@ import pytest
 
 from pydantic import ValidationError
 
-from deck import WellPlate, Vial, Coordinate3D, Deck
+from deck import WellPlate, Vial, Coordinate3D, Deck, TipRack
 from deck.loader import (
     DeckLoaderError,
     _PlateOrientation,
@@ -925,3 +925,82 @@ class TestResolvePlateOrientation:
         assert isinstance(orient, _PlateOrientation)
         with pytest.raises(AttributeError):
             orient.col_delta_x = 99.0
+
+
+# ----- TipRack dimension forwarding -----
+
+TIPRACK_WITH_EXPLICIT_DIMS = """
+labware:
+  rack:
+    type: tip_rack
+    name: test_rack
+    rows: 1
+    columns: 2
+    length_mm: 130.0
+    width_mm: 5.0
+    height_mm: 40.0
+    z_pickup: 30.0
+    calibration:
+      a1:
+        x: 10.0
+        y: 50.0
+      a2:
+        x: 110.0
+        y: 50.0
+    x_offset_mm: 100.0
+    y_offset_mm: 1.0
+"""
+
+TIPRACK_WITHOUT_EXPLICIT_DIMS = """
+labware:
+  rack:
+    type: tip_rack
+    name: test_rack
+    rows: 1
+    columns: 2
+    z_pickup: 30.0
+    calibration:
+      a1:
+        x: 10.0
+        y: 50.0
+      a2:
+        x: 110.0
+        y: 50.0
+    x_offset_mm: 100.0
+    y_offset_mm: 1.0
+"""
+
+
+class TestTipRackDimensionForwarding:
+
+    def test_explicit_dimensions_preserved(self):
+        """YAML-specified length/width/height must not be overridden by auto-derivation."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(TIPRACK_WITH_EXPLICIT_DIMS)
+            path = f.name
+        try:
+            deck = load_deck_from_yaml(path)
+            rack = deck["rack"]
+            assert isinstance(rack, TipRack)
+            assert rack.length_mm == pytest.approx(130.0)
+            assert rack.width_mm == pytest.approx(5.0)
+            assert rack.height_mm == pytest.approx(40.0)
+        finally:
+            Path(path).unlink(missing_ok=True)
+
+    def test_omitted_dimensions_auto_derived(self):
+        """When dimensions are omitted, TipRack should auto-derive from tip positions."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(TIPRACK_WITHOUT_EXPLICIT_DIMS)
+            path = f.name
+        try:
+            deck = load_deck_from_yaml(path)
+            rack = deck["rack"]
+            assert isinstance(rack, TipRack)
+            # Auto-derived: length from tip spread (110-10=100), width clamped to 1.0
+            assert rack.length_mm == pytest.approx(100.0)
+            assert rack.width_mm == pytest.approx(1.0)
+            # height auto-derives to 1.0 when z_drop is not provided
+            assert rack.height_mm == pytest.approx(1.0)
+        finally:
+            Path(path).unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
- `_build_tip_rack` was manually listing fields to pass to the TipRack constructor, missing `height_mm`, `width_mm`, and `length_mm`
- Switched to `_entry_kwargs_for_model` (same pattern as `_build_holder` and other builders) so all matching YAML fields are forwarded
- Without this fix, YAML-specified dimensions are silently dropped and auto-derived as 1.0mm from tip positions

## Test plan
- [ ] Verify tip rack with explicit `height_mm`, `width_mm`, `length_mm` in deck YAML retains those values after loading
- [ ] Verify existing tip rack YAMLs without explicit dimensions still auto-derive correctly
- [ ] Run existing deck loader tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)