### PR TITLE
Prevent unsafe protocol setups before hardware motion

### DIFF
--- a/src/board/loader.py
+++ b/src/board/loader.py
@@ -89,11 +89,13 @@ def load_board_from_yaml(
         kwargs = entry.model_dump()
         type_key = kwargs.pop("type")
         vendor = kwargs.pop("vendor")
+        collision_geometry = kwargs.pop("collision_geometry", None)
         validate_instrument(type_key, vendor)
         if mock_mode:
             kwargs["offline"] = True
         cls = get_instrument_class(type_key)
         instruments[name] = cls(**kwargs)
+        instruments[name].collision_geometry = collision_geometry
 
     return Board(gantry=gantry, instruments=instruments)
 

--- a/src/board/yaml_schema.py
+++ b/src/board/yaml_schema.py
@@ -4,7 +4,49 @@ from __future__ import annotations
 
 from typing import Dict
 
-from pydantic import BaseModel, ConfigDict
+import math
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+class CollisionVectorYaml(BaseModel):
+    """Three-dimensional vector used by instrument collision geometry."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    x: float
+    y: float
+    z: float
+
+    @field_validator("x", "y", "z")
+    def _validate_finite(cls, value: float, info):  # type: ignore[override]
+        if not math.isfinite(value):
+            raise ValueError(f"{info.field_name} must be finite.")
+        return value
+
+
+class CollisionGeometryYaml(BaseModel):
+    """Conservative instrument body geometry relative to the working point."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: str = "box"
+    size: CollisionVectorYaml
+    origin_offset: CollisionVectorYaml = Field(
+        default_factory=lambda: CollisionVectorYaml(x=0.0, y=0.0, z=0.0),
+    )
+
+    @field_validator("kind")
+    def _validate_kind(cls, value: str) -> str:
+        if value != "box":
+            raise ValueError("collision_geometry.kind must be 'box'.")
+        return value
+
+    @model_validator(mode="after")
+    def _validate_size_positive(self) -> "CollisionGeometryYaml":
+        if self.size.x <= 0 or self.size.y <= 0 or self.size.z <= 0:
+            raise ValueError("collision_geometry.size dimensions must be positive.")
+        return self
 
 
 class InstrumentYamlEntry(BaseModel):
@@ -22,6 +64,7 @@ class InstrumentYamlEntry(BaseModel):
     offset_y: float = 0.0
     depth: float = 0.0
     measurement_height: float = 0.0
+    collision_geometry: CollisionGeometryYaml | None = None
 
 
 class BoardYamlSchema(BaseModel):

--- a/src/instruments/base_instrument.py
+++ b/src/instruments/base_instrument.py
@@ -30,6 +30,7 @@ class BaseInstrument(ABC):
         self.offset_y = offset_y
         self.depth = depth
         self.measurement_height = measurement_height
+        self.collision_geometry: Any = None
         self._offline = offline
         self.logger = logging.getLogger(f"{__name__}.{self.name}")
 

--- a/src/protocol_engine/setup.py
+++ b/src/protocol_engine/setup.py
@@ -15,7 +15,12 @@ from gantry.loader import load_gantry_from_yaml_safe
 from protocol_engine.loader import load_protocol_from_yaml_safe
 from protocol_engine.protocol import Protocol, ProtocolContext
 from validation.bounds import validate_deck_positions, validate_gantry_positions
-from validation.errors import SetupValidationError
+from validation.collision import (
+    CollisionSettings,
+    CollisionValidationMode,
+    validate_collision_safety,
+)
+from validation.errors import CollisionValidationError, SetupValidationError
 
 
 def setup_protocol(
@@ -25,6 +30,9 @@ def setup_protocol(
     protocol_path: str | Path,
     gantry=None,
     mock_mode: bool = False,
+    collision_validation: bool = False,
+    collision_mode: str = "strict",
+    collision_clearance_mm: float = 2.0,
 ) -> Tuple[Protocol, ProtocolContext]:
     """Load all configs, validate bounds, and return a ready-to-run protocol.
 
@@ -45,6 +53,10 @@ def setup_protocol(
         gantry: Optional Gantry instance. If None, an offline Gantry is used
             for validation.
         mock_mode: If True, instantiate real driver classes in offline mode.
+        collision_validation: If True, run opt-in static collision validation.
+        collision_mode: 'strict' blocks setup on missing geometry; 'report_only'
+            records missing geometry as warnings.
+        collision_clearance_mm: Required Z clearance for static envelope checks.
 
     Returns:
         Tuple of (Protocol, ProtocolContext) ready for ``protocol.run(context)``.
@@ -76,6 +88,20 @@ def setup_protocol(
         raise SetupValidationError(violations)
 
     context = ProtocolContext(board=board, deck=deck, positions=protocol.positions, gantry=gantry_config)
+    if collision_validation:
+        settings = CollisionSettings(
+            mode=CollisionValidationMode(collision_mode),
+            clearance_mm=collision_clearance_mm,
+        )
+        collision_report = validate_collision_safety(
+            protocol,
+            context,
+            gantry_config,
+            settings=settings,
+        )
+        context.collision_report = collision_report
+        if collision_report.errors:
+            raise CollisionValidationError(collision_report.issues)
     return protocol, context
 
 
@@ -86,6 +112,9 @@ def run_protocol(
     protocol_path: str | Path,
     gantry=None,
     mock_mode: bool = False,
+    collision_validation: bool = False,
+    collision_mode: str = "strict",
+    collision_clearance_mm: float = 2.0,
 ) -> List[Any]:
     """Load configs, validate, and execute the protocol in one call.
 
@@ -98,6 +127,9 @@ def run_protocol(
     protocol, context = setup_protocol(
         gantry_path, deck_path, board_path, protocol_path,
         gantry=gantry, mock_mode=mock_mode,
+        collision_validation=collision_validation,
+        collision_mode=collision_mode,
+        collision_clearance_mm=collision_clearance_mm,
     )
     context.board.connect_instruments()
     try:

--- a/src/validation/__init__.py
+++ b/src/validation/__init__.py
@@ -1,11 +1,40 @@
 """Validation module for protocol setup."""
 
 from .bounds import validate_deck_positions, validate_gantry_positions
-from .errors import BoundsViolation, SetupValidationError
+from .collision import (
+    CollisionBox,
+    CollisionEnvelope,
+    CollisionPose,
+    CollisionReport,
+    CollisionSettings,
+    CollisionValidationMode,
+    build_labware_envelopes,
+    compute_required_safe_z,
+    extract_collision_poses,
+    validate_collision_safety,
+)
+from .errors import (
+    BoundsViolation,
+    CollisionIssue,
+    CollisionValidationError,
+    SetupValidationError,
+)
 
 __all__ = [
     "BoundsViolation",
+    "CollisionBox",
+    "CollisionEnvelope",
+    "CollisionIssue",
+    "CollisionPose",
+    "CollisionReport",
+    "CollisionSettings",
+    "CollisionValidationError",
+    "CollisionValidationMode",
     "SetupValidationError",
+    "build_labware_envelopes",
+    "compute_required_safe_z",
+    "extract_collision_poses",
     "validate_deck_positions",
     "validate_gantry_positions",
+    "validate_collision_safety",
 ]

--- a/src/validation/collision.py
+++ b/src/validation/collision.py
@@ -1,0 +1,698 @@
+"""Static pre-run collision validation for protocol setup.
+
+The v1 model is intentionally conservative and dependency-free. It validates
+axis-aligned envelopes at safe-Z and working poses; it does not perform path
+planning, swept-volume checks, or layout optimization.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Iterable, Literal
+
+from board.board import Board
+from deck.deck import Deck
+from deck.labware.holder import HolderLabware
+from deck.labware.labware import Coordinate3D, Labware
+from deck.labware.tip_rack import TipRack
+from deck.labware.well_plate import WellPlate
+from gantry.gantry_config import GantryConfig, WorkingVolume
+from protocol_engine.protocol import Protocol, ProtocolContext, ProtocolStep
+
+from .errors import CollisionIssue
+
+
+class CollisionValidationMode(str, Enum):
+    """Strictness for collision validation."""
+
+    STRICT = "strict"
+    REPORT_ONLY = "report_only"
+
+
+@dataclass(frozen=True)
+class CollisionSettings:
+    """Configuration for static collision validation."""
+
+    mode: CollisionValidationMode = CollisionValidationMode.STRICT
+    clearance_mm: float = 2.0
+
+    def __post_init__(self) -> None:
+        if not math.isfinite(self.clearance_mm) or self.clearance_mm < 0:
+            raise ValueError("clearance_mm must be a finite non-negative number.")
+
+
+@dataclass(frozen=True)
+class CollisionBox:
+    """Axis-aligned bounding box in user-facing deck coordinates."""
+
+    x_min: float
+    x_max: float
+    y_min: float
+    y_max: float
+    z_min: float
+    z_max: float
+
+    def __post_init__(self) -> None:
+        if self.x_min > self.x_max:
+            raise ValueError("x_min must be <= x_max.")
+        if self.y_min > self.y_max:
+            raise ValueError("y_min must be <= y_max.")
+        if self.z_min > self.z_max:
+            raise ValueError("z_min must be <= z_max.")
+
+    @classmethod
+    def from_origin_size(
+        cls,
+        *,
+        origin_x: float,
+        origin_y: float,
+        origin_z: float,
+        size_x: float,
+        size_y: float,
+        size_z: float,
+    ) -> "CollisionBox":
+        if size_x <= 0 or size_y <= 0 or size_z <= 0:
+            raise ValueError("Collision dimensions must be positive.")
+        return cls(
+            x_min=origin_x,
+            x_max=origin_x + size_x,
+            y_min=origin_y,
+            y_max=origin_y + size_y,
+            z_min=origin_z,
+            z_max=origin_z + size_z,
+        )
+
+    @classmethod
+    def from_center_base(
+        cls,
+        *,
+        center_x: float,
+        center_y: float,
+        base_z: float,
+        size_x: float,
+        size_y: float,
+        size_z: float,
+    ) -> "CollisionBox":
+        if size_x <= 0 or size_y <= 0 or size_z <= 0:
+            raise ValueError("Collision dimensions must be positive.")
+        return cls(
+            x_min=center_x - size_x / 2,
+            x_max=center_x + size_x / 2,
+            y_min=center_y - size_y / 2,
+            y_max=center_y + size_y / 2,
+            z_min=base_z,
+            z_max=base_z + size_z,
+        )
+
+    def translated(self, dx: float, dy: float, dz: float) -> "CollisionBox":
+        return CollisionBox(
+            x_min=self.x_min + dx,
+            x_max=self.x_max + dx,
+            y_min=self.y_min + dy,
+            y_max=self.y_max + dy,
+            z_min=self.z_min + dz,
+            z_max=self.z_max + dz,
+        )
+
+    def intersects(self, other: "CollisionBox") -> bool:
+        """Return True when boxes overlap with positive volume."""
+        return (
+            self.x_min < other.x_max
+            and self.x_max > other.x_min
+            and self.y_min < other.y_max
+            and self.y_max > other.y_min
+            and self.z_min < other.z_max
+            and self.z_max > other.z_min
+        )
+
+    def overlaps_xy(self, other: "CollisionBox") -> bool:
+        return (
+            self.x_min < other.x_max
+            and self.x_max > other.x_min
+            and self.y_min < other.y_max
+            and self.y_max > other.y_min
+        )
+
+    def contained_by(self, volume: WorkingVolume) -> bool:
+        return (
+            volume.x_min <= self.x_min <= self.x_max <= volume.x_max
+            and volume.y_min <= self.y_min <= self.y_max <= volume.y_max
+            and volume.z_min <= self.z_min <= self.z_max <= volume.z_max
+        )
+
+
+@dataclass(frozen=True)
+class CollisionEnvelope:
+    """Named physical collision envelope."""
+
+    key: str
+    owner_type: Literal["labware", "instrument"]
+    box: CollisionBox
+
+
+@dataclass(frozen=True)
+class CollisionPose:
+    """One protocol pose to validate statically."""
+
+    step_index: int
+    command_name: str
+    active_instrument: str
+    target: Coordinate3D
+    target_key: str | None = None
+    purpose: str = "working_pose"
+
+
+@dataclass
+class CollisionReport:
+    """Structured collision validation report."""
+
+    issues: list[CollisionIssue] = field(default_factory=list)
+    suggestions: list[str] = field(default_factory=list)
+
+    @property
+    def errors(self) -> list[CollisionIssue]:
+        return [issue for issue in self.issues if issue.severity == "error"]
+
+    @property
+    def warnings(self) -> list[CollisionIssue]:
+        return [issue for issue in self.issues if issue.severity == "warning"]
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+    def add_issue(
+        self,
+        *,
+        severity: Literal["error", "warning", "suggestion"],
+        code: str,
+        message: str,
+        step_index: int | None = None,
+        command_name: str | None = None,
+        active_instrument: str | None = None,
+        body_a: str | None = None,
+        body_b: str | None = None,
+    ) -> None:
+        self.issues.append(
+            CollisionIssue(
+                severity=severity,
+                code=code,
+                message=message,
+                step_index=step_index,
+                command_name=command_name,
+                active_instrument=active_instrument,
+                body_a=body_a,
+                body_b=body_b,
+            )
+        )
+
+
+def _issue_severity(settings: CollisionSettings) -> Literal["error", "warning"]:
+    if settings.mode == CollisionValidationMode.STRICT:
+        return "error"
+    return "warning"
+
+
+def _dimensions_from_geometry(labware: Labware) -> tuple[float, float, float] | None:
+    geometry = getattr(labware, "geometry", None)
+    if geometry is None:
+        return None
+    length = geometry.length_mm
+    width = geometry.width_mm
+    height = geometry.height_mm
+    if length is None or width is None or height is None:
+        return None
+    return (length, width, height)
+
+
+def _positions_xy_box(
+    positions: Iterable[Coordinate3D],
+    *,
+    fallback_center: Coordinate3D,
+    length_mm: float,
+    width_mm: float,
+    height_mm: float,
+) -> CollisionBox:
+    coords = list(positions)
+    if not coords:
+        return CollisionBox.from_center_base(
+            center_x=fallback_center.x,
+            center_y=fallback_center.y,
+            base_z=fallback_center.z,
+            size_x=length_mm,
+            size_y=width_mm,
+            size_z=height_mm,
+        )
+
+    min_x = min(coord.x for coord in coords)
+    max_x = max(coord.x for coord in coords)
+    min_y = min(coord.y for coord in coords)
+    max_y = max(coord.y for coord in coords)
+    min_z = min(coord.z for coord in coords)
+    spread_x = max_x - min_x
+    spread_y = max_y - min_y
+    pad_x = max((length_mm - spread_x) / 2, 0.0)
+    pad_y = max((width_mm - spread_y) / 2, 0.0)
+    return CollisionBox(
+        x_min=min_x - pad_x,
+        x_max=max_x + pad_x,
+        y_min=min_y - pad_y,
+        y_max=max_y + pad_y,
+        z_min=min_z,
+        z_max=min_z + height_mm,
+    )
+
+
+def build_labware_envelopes(
+    deck: Deck,
+    *,
+    settings: CollisionSettings | None = None,
+) -> tuple[list[CollisionEnvelope], CollisionReport]:
+    """Build conservative deck-space envelopes for all labware."""
+    settings = settings or CollisionSettings()
+    report = CollisionReport()
+    envelopes: list[CollisionEnvelope] = []
+
+    def add_labware(key: str, labware: Labware) -> None:
+        dims = _dimensions_from_geometry(labware)
+        if dims is None:
+            report.add_issue(
+                severity=_issue_severity(settings),
+                code="missing_labware_geometry",
+                message=f"Labware '{key}' is missing collision dimensions.",
+                body_a=key,
+            )
+            return
+
+        length, width, height = dims
+        if isinstance(labware, (WellPlate, TipRack)):
+            box = _positions_xy_box(
+                labware.iter_positions().values(),
+                fallback_center=labware.get_initial_position(),
+                length_mm=length,
+                width_mm=width,
+                height_mm=height,
+            )
+        else:
+            loc = labware.get_initial_position()
+            box = CollisionBox.from_center_base(
+                center_x=loc.x,
+                center_y=loc.y,
+                base_z=loc.z,
+                size_x=length,
+                size_y=width,
+                size_z=height,
+            )
+
+        envelopes.append(CollisionEnvelope(key=key, owner_type="labware", box=box))
+
+        if isinstance(labware, HolderLabware):
+            for child_key, child in labware.contained_labware.items():
+                add_labware(f"{key}.{child_key}", child)
+
+    for key in deck:
+        add_labware(key, deck[key])
+
+    return envelopes, report
+
+
+def _dict_get_xyz(data: Any, key: str) -> tuple[float, float, float] | None:
+    value = data.get(key) if isinstance(data, dict) else getattr(data, key, None)
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return (float(value["x"]), float(value["y"]), float(value["z"]))
+    return (float(value.x), float(value.y), float(value.z))
+
+
+def instrument_envelope_at(
+    *,
+    instrument_name: str,
+    instrument: Any,
+    gantry_x: float,
+    gantry_y: float,
+    gantry_z: float,
+) -> CollisionEnvelope | None:
+    """Return an instrument envelope at a gantry pose, if geometry exists."""
+    geometry = getattr(instrument, "collision_geometry", None)
+    if geometry is None:
+        return None
+    size = _dict_get_xyz(geometry, "size")
+    origin_offset = _dict_get_xyz(geometry, "origin_offset") or (0.0, 0.0, 0.0)
+    if size is None:
+        return None
+
+    point_x = gantry_x + float(instrument.offset_x)
+    point_y = gantry_y + float(instrument.offset_y)
+    point_z = gantry_z + float(instrument.depth)
+    box = CollisionBox.from_origin_size(
+        origin_x=point_x + origin_offset[0],
+        origin_y=point_y + origin_offset[1],
+        origin_z=point_z + origin_offset[2],
+        size_x=size[0],
+        size_y=size[1],
+        size_z=size[2],
+    )
+    return CollisionEnvelope(key=instrument_name, owner_type="instrument", box=box)
+
+
+def _resolve_target_info(context: ProtocolContext, position: Any) -> tuple[Coordinate3D, str | None]:
+    if isinstance(position, (list, tuple)):
+        return (
+            Coordinate3D(
+                x=float(position[0]),
+                y=float(position[1]),
+                z=float(position[2]),
+            ),
+            None,
+        )
+    if isinstance(position, str) and position in context.positions:
+        coords = context.positions[position]
+        return (
+            Coordinate3D(
+                x=float(coords[0]),
+                y=float(coords[1]),
+                z=float(coords[2]),
+            ),
+            None,
+        )
+    if isinstance(position, str):
+        return context.deck.resolve(position), position
+    raise TypeError(f"Unsupported protocol target position: {position!r}")
+
+
+def _row_major_key(well_id: str) -> tuple[str, int]:
+    return (well_id[0], int(well_id[1:]))
+
+
+def _wells_for_axis(plate: WellPlate, axis: str) -> list[str]:
+    if axis.isalpha():
+        wells = [well for well in plate.wells if well[0] == axis.upper()]
+    else:
+        wells = [well for well in plate.wells if well[1:] == axis]
+    return sorted(wells, key=_row_major_key)
+
+
+def _pose(
+    step: ProtocolStep,
+    *,
+    active_instrument: str,
+    target: Coordinate3D,
+    target_key: str | None,
+    purpose: str = "working_pose",
+) -> CollisionPose:
+    return CollisionPose(
+        step_index=step.index,
+        command_name=step.command_name,
+        active_instrument=active_instrument,
+        target=target,
+        target_key=target_key,
+        purpose=purpose,
+    )
+
+
+def extract_collision_poses(
+    protocol: Protocol,
+    context: ProtocolContext,
+    *,
+    settings: CollisionSettings | None = None,
+) -> tuple[list[CollisionPose], CollisionReport]:
+    """Extract static validation poses from a loaded protocol."""
+    settings = settings or CollisionSettings()
+    report = CollisionReport()
+    poses: list[CollisionPose] = []
+
+    for step in protocol.steps:
+        args = step.args
+        command = step.command_name
+
+        try:
+            if command == "move":
+                target, target_key = _resolve_target_info(context, args["position"])
+                poses.append(_pose(
+                    step, active_instrument=args["instrument"],
+                    target=target, target_key=target_key,
+                ))
+            elif command in {"aspirate", "blowout", "mix", "pick_up_tip", "drop_tip"}:
+                target, target_key = _resolve_target_info(context, args["position"])
+                poses.append(_pose(
+                    step, active_instrument="pipette",
+                    target=target, target_key=target_key,
+                ))
+            elif command == "transfer":
+                source, source_key = _resolve_target_info(context, args["source"])
+                dest, dest_key = _resolve_target_info(context, args["destination"])
+                poses.append(_pose(
+                    step, active_instrument="pipette",
+                    target=source, target_key=source_key, purpose="source",
+                ))
+                poses.append(_pose(
+                    step, active_instrument="pipette",
+                    target=dest, target_key=dest_key, purpose="destination",
+                ))
+            elif command == "serial_transfer":
+                source, source_key = _resolve_target_info(context, args["source"])
+                poses.append(_pose(
+                    step, active_instrument="pipette",
+                    target=source, target_key=source_key, purpose="source",
+                ))
+                plate = context.deck[args["plate"]]
+                if not isinstance(plate, WellPlate):
+                    raise TypeError("serial_transfer plate target must be a WellPlate.")
+                for well_id in _wells_for_axis(plate, args["axis"]):
+                    target_key = f"{args['plate']}.{well_id}"
+                    poses.append(_pose(
+                        step,
+                        active_instrument="pipette",
+                        target=plate.get_well_center(well_id),
+                        target_key=target_key,
+                        purpose="destination",
+                    ))
+            elif command == "scan":
+                plate = context.deck[args["plate"]]
+                if not isinstance(plate, WellPlate):
+                    raise TypeError("scan plate target must be a WellPlate.")
+                instrument_name = args["instrument"]
+                instr = context.board.instruments[instrument_name]
+                for well_id in sorted(plate.wells, key=_row_major_key):
+                    well = plate.get_well_center(well_id)
+                    poses.append(_pose(
+                        step,
+                        active_instrument=instrument_name,
+                        target=Coordinate3D(
+                            x=well.x,
+                            y=well.y,
+                            z=well.z - float(instr.measurement_height),
+                        ),
+                        target_key=f"{args['plate']}.{well_id}",
+                    ))
+            elif command == "measure":
+                instrument_name = args["instrument"]
+                instr = context.board.instruments[instrument_name]
+                coord, target_key = _resolve_target_info(context, args["position"])
+                poses.append(_pose(
+                    step,
+                    active_instrument=instrument_name,
+                    target=Coordinate3D(
+                        x=coord.x,
+                        y=coord.y,
+                        z=coord.z + float(instr.measurement_height),
+                    ),
+                    target_key=target_key,
+                ))
+            elif command in {"home", "pause", "breakpoint"}:
+                continue
+            else:
+                report.add_issue(
+                    severity=_issue_severity(settings),
+                    code="unsupported_command",
+                    message=(
+                        f"Command '{command}' has no collision pose extractor; "
+                        "mark it collision-noop or add extraction support."
+                    ),
+                    step_index=step.index,
+                    command_name=command,
+                )
+        except Exception as exc:
+            report.add_issue(
+                severity=_issue_severity(settings),
+                code="pose_extraction_failed",
+                message=f"Could not extract collision pose for command '{command}': {exc}",
+                step_index=step.index,
+                command_name=command,
+            )
+
+    return poses, report
+
+
+def _allowed_labware_keys(
+    target_key: str | None,
+    labware_envelopes: list[CollisionEnvelope],
+) -> set[str]:
+    """Return labware envelopes the active instrument may intentionally touch."""
+    if target_key is None:
+        return set()
+    envelope_keys = {envelope.key for envelope in labware_envelopes}
+    if target_key in envelope_keys:
+        return {target_key}
+    matching_prefixes = [
+        key for key in envelope_keys
+        if target_key.startswith(f"{key}.")
+    ]
+    if matching_prefixes:
+        return {max(matching_prefixes, key=len)}
+    return set()
+
+
+def _gantry_for_pose(board: Board, pose: CollisionPose) -> tuple[float, float, float] | None:
+    instrument = board.instruments.get(pose.active_instrument)
+    if instrument is None:
+        return None
+    return (
+        pose.target.x - float(instrument.offset_x),
+        pose.target.y - float(instrument.offset_y),
+        pose.target.z - float(instrument.depth),
+    )
+
+
+def compute_required_safe_z(
+    labware_envelopes: list[CollisionEnvelope],
+    *,
+    clearance_mm: float,
+) -> float:
+    if not labware_envelopes:
+        return clearance_mm
+    # CubOS user-facing Z is positive-down, so a smaller Z is higher/safer.
+    return min(envelope.box.z_min for envelope in labware_envelopes) - clearance_mm
+
+
+def validate_collision_safety(
+    protocol: Protocol,
+    context: ProtocolContext,
+    gantry: GantryConfig,
+    *,
+    settings: CollisionSettings | None = None,
+) -> CollisionReport:
+    """Validate static collision safety for a loaded protocol setup."""
+    settings = settings or CollisionSettings()
+    report = CollisionReport()
+
+    labware_envelopes, labware_report = build_labware_envelopes(
+        context.deck, settings=settings,
+    )
+    report.issues.extend(labware_report.issues)
+
+    volume = gantry.working_volume
+    for envelope in labware_envelopes:
+        if not envelope.box.contained_by(volume):
+            report.add_issue(
+                severity=_issue_severity(settings),
+                code="labware_out_of_volume",
+                message=f"Labware envelope '{envelope.key}' is outside the gantry working volume.",
+                body_a=envelope.key,
+            )
+
+    required_safe_z = compute_required_safe_z(
+        labware_envelopes, clearance_mm=settings.clearance_mm,
+    )
+    if required_safe_z < volume.z_min:
+        report.add_issue(
+            severity=_issue_severity(settings),
+            code="safe_z_out_of_volume",
+            message=(
+                f"Required safe_z {required_safe_z:.3f} is above "
+                f"working volume z_min {volume.z_min:.3f}."
+            ),
+        )
+        report.suggestions.append(
+            "Lower labware height, reduce required clearance, or use a gantry with more upward Z clearance."
+        )
+
+    poses, pose_report = extract_collision_poses(
+        protocol, context, settings=settings,
+    )
+    report.issues.extend(pose_report.issues)
+
+    missing_instruments_reported: set[str] = set()
+    for pose in poses:
+        allowed_labware = _allowed_labware_keys(pose.target_key, labware_envelopes)
+        gantry_position = _gantry_for_pose(context.board, pose)
+        if gantry_position is None:
+            report.add_issue(
+                severity=_issue_severity(settings),
+                code="unknown_instrument",
+                message=f"Unknown active instrument '{pose.active_instrument}'.",
+                step_index=pose.step_index,
+                command_name=pose.command_name,
+                active_instrument=pose.active_instrument,
+            )
+            continue
+
+        gx, gy, gz = gantry_position
+        instrument_envelopes: list[CollisionEnvelope] = []
+        for name, instrument in context.board.instruments.items():
+            envelope = instrument_envelope_at(
+                instrument_name=name,
+                instrument=instrument,
+                gantry_x=gx,
+                gantry_y=gy,
+                gantry_z=gz,
+            )
+            if envelope is None:
+                if name in missing_instruments_reported:
+                    continue
+                missing_instruments_reported.add(name)
+                report.add_issue(
+                    severity=_issue_severity(settings),
+                    code="missing_instrument_geometry",
+                    message=f"Instrument '{name}' is missing collision_geometry.",
+                    step_index=pose.step_index,
+                    command_name=pose.command_name,
+                    active_instrument=pose.active_instrument,
+                    body_a=name,
+                )
+                continue
+            instrument_envelopes.append(envelope)
+
+        for envelope in instrument_envelopes:
+            if not envelope.box.contained_by(volume):
+                report.add_issue(
+                    severity=_issue_severity(settings),
+                    code="instrument_out_of_volume",
+                    message=(
+                        f"Instrument envelope '{envelope.key}' at step {pose.step_index} "
+                        "is outside the gantry working volume."
+                    ),
+                    step_index=pose.step_index,
+                    command_name=pose.command_name,
+                    active_instrument=pose.active_instrument,
+                    body_a=envelope.key,
+                )
+
+            for labware in labware_envelopes:
+                if envelope.key == pose.active_instrument and labware.key in allowed_labware:
+                    continue
+                if not envelope.box.overlaps_xy(labware.box):
+                    continue
+                if envelope.box.z_max <= labware.box.z_min - settings.clearance_mm:
+                    continue
+                report.add_issue(
+                    severity=_issue_severity(settings),
+                    code="instrument_labware_collision",
+                    message=(
+                        f"Instrument '{envelope.key}' overlaps labware '{labware.key}' "
+                        f"without {settings.clearance_mm:.3f} mm Z clearance."
+                    ),
+                    step_index=pose.step_index,
+                    command_name=pose.command_name,
+                    active_instrument=pose.active_instrument,
+                    body_a=envelope.key,
+                    body_b=labware.key,
+                )
+                report.suggestions.append(
+                    "Increase safe-Z clearance, move the labware, or adjust the instrument offset/geometry."
+                )
+
+    return report

--- a/src/validation/errors.py
+++ b/src/validation/errors.py
@@ -39,3 +39,38 @@ class SetupValidationError(Exception):
             f"Bounds validation failed with {len(self.violations)} violation(s):\n"
             + "\n".join(messages)
         )
+
+
+@dataclass(frozen=True)
+class CollisionIssue:
+    """One collision validation error, warning, or suggestion."""
+
+    severity: Literal["error", "warning", "suggestion"]
+    code: str
+    message: str
+    step_index: int | None = None
+    command_name: str | None = None
+    active_instrument: str | None = None
+    body_a: str | None = None
+    body_b: str | None = None
+
+
+class CollisionValidationError(Exception):
+    """Raised when collision validation blocks protocol setup."""
+
+    def __init__(self, issues: list[CollisionIssue]) -> None:
+        self.issues: Tuple[CollisionIssue, ...] = tuple(issues)
+        errors = [issue for issue in self.issues if issue.severity == "error"]
+        messages = []
+        for issue in errors:
+            location = ""
+            if issue.step_index is not None:
+                location = f"step {issue.step_index}"
+                if issue.command_name:
+                    location += f" ({issue.command_name})"
+                location += ": "
+            messages.append(f"  {location}{issue.message}")
+        super().__init__(
+            f"Collision validation failed with {len(errors)} error(s):\n"
+            + "\n".join(messages)
+        )

--- a/tests/board/test_board_loader.py
+++ b/tests/board/test_board_loader.py
@@ -49,10 +49,37 @@ class TestInstrumentYamlEntry:
         assert entry.offset_y == 0.0
         assert entry.depth == 0.0
         assert entry.measurement_height == 0.0
+        assert entry.collision_geometry is None
 
     def test_missing_vendor_raises(self):
         with pytest.raises(Exception):
             InstrumentYamlEntry(type="uvvis_ccs")
+
+    def test_accepts_collision_geometry(self):
+        entry = InstrumentYamlEntry.model_validate({
+            "type": "uvvis_ccs",
+            "vendor": "thorlabs",
+            "collision_geometry": {
+                "kind": "box",
+                "size": {"x": 10.0, "y": 20.0, "z": 30.0},
+                "origin_offset": {"x": -5.0, "y": -10.0, "z": 0.0},
+            },
+        })
+
+        assert entry.collision_geometry is not None
+        assert entry.collision_geometry.size.x == 10.0
+        assert entry.collision_geometry.origin_offset.y == -10.0
+
+    def test_rejects_invalid_collision_geometry_size(self):
+        with pytest.raises(Exception, match="positive"):
+            InstrumentYamlEntry.model_validate({
+                "type": "uvvis_ccs",
+                "vendor": "thorlabs",
+                "collision_geometry": {
+                    "kind": "box",
+                    "size": {"x": 0.0, "y": 20.0, "z": 30.0},
+                },
+            })
 
 
 class TestBoardYamlSchema:
@@ -158,6 +185,28 @@ class TestLoadBoardMeasurementHeight:
         """)
         board = load_board_from_yaml(yaml_path, _mock_gantry())
         assert board.instruments["sensor"].measurement_height == 0.0
+
+
+class TestLoadBoardCollisionGeometry:
+
+    def test_collision_geometry_attaches_to_instrument(self, tmp_path):
+        yaml_path = _write_yaml(tmp_path, """\
+            instruments:
+              sensor:
+                type: uvvis_ccs
+                vendor: thorlabs
+                collision_geometry:
+                  kind: box
+                  size: {x: 10.0, y: 20.0, z: 30.0}
+                  origin_offset: {x: -5.0, y: -10.0, z: 1.0}
+        """)
+
+        board = load_board_from_yaml(yaml_path, _mock_gantry())
+
+        geometry = board.instruments["sensor"].collision_geometry
+        assert geometry["kind"] == "box"
+        assert geometry["size"]["x"] == 10.0
+        assert geometry["origin_offset"]["z"] == 1.0
 
 
 class TestLoadBoardGantry:

--- a/tests/setup/test_protocol_setup.py
+++ b/tests/setup/test_protocol_setup.py
@@ -16,7 +16,7 @@ from protocol_engine.errors import ProtocolLoaderError
 from protocol_engine.protocol import Protocol, ProtocolContext
 from protocol_engine.registry import CommandRegistry
 from protocol_engine.setup import run_protocol, setup_protocol
-from validation.errors import SetupValidationError
+from validation.errors import CollisionValidationError, SetupValidationError
 
 
 @pytest.fixture(autouse=True)
@@ -72,6 +72,37 @@ instruments:
     offset_y: 0.0
     depth: 0.0
     measurement_height: 0.0
+"""
+
+SMALL_DECK_YAML = """\
+labware:
+  vial_1:
+    type: vial
+    name: test_vial
+    model_name: standard_vial
+    height_mm: 10.0
+    diameter_mm: 10.0
+    location:
+      x: 30.0
+      y: 40.0
+      z: 20.0
+    capacity_ul: 1500.0
+    working_volume_ul: 1200.0
+"""
+
+BOARD_WITH_COLLISION_YAML = """\
+instruments:
+  pipette:
+    type: pipette
+    vendor: opentrons
+    offset_x: 5.0
+    offset_y: 0.0
+    depth: 0.0
+    measurement_height: 0.0
+    collision_geometry:
+      kind: box
+      size: {x: 4.0, y: 4.0, z: 4.0}
+      origin_offset: {x: -2.0, y: -2.0, z: -12.0}
 """
 
 PROTOCOL_YAML = """\
@@ -298,6 +329,60 @@ instruments:
             from instruments.pipette.driver import Pipette
             assert isinstance(context.board.instruments["pipette"], Pipette)
             assert context.board.instruments["pipette"]._offline is True
+
+    def test_collision_validation_is_opt_in(self):
+        with _TempYamlFiles() as f:
+            protocol, context = setup_protocol(
+                f.gantry_path, f.deck_path, f.board_path, f.protocol_path,
+            )
+
+            assert isinstance(protocol, Protocol)
+            assert not hasattr(context, "collision_report")
+
+    def test_collision_validation_strict_fails_missing_geometry(self):
+        with _TempYamlFiles(deck=SMALL_DECK_YAML) as f:
+            with pytest.raises(CollisionValidationError) as exc_info:
+                setup_protocol(
+                    f.gantry_path,
+                    f.deck_path,
+                    f.board_path,
+                    f.protocol_path,
+                    collision_validation=True,
+                )
+
+            assert any(
+                issue.code == "missing_instrument_geometry"
+                for issue in exc_info.value.issues
+            )
+
+    def test_collision_validation_report_only_allows_missing_geometry(self):
+        with _TempYamlFiles(deck=SMALL_DECK_YAML) as f:
+            _, context = setup_protocol(
+                f.gantry_path,
+                f.deck_path,
+                f.board_path,
+                f.protocol_path,
+                collision_validation=True,
+                collision_mode="report_only",
+            )
+
+            assert context.collision_report.ok
+            assert any(
+                issue.code == "missing_instrument_geometry"
+                for issue in context.collision_report.warnings
+            )
+
+    def test_collision_validation_strict_passes_with_complete_geometry(self):
+        with _TempYamlFiles(deck=SMALL_DECK_YAML, board=BOARD_WITH_COLLISION_YAML) as f:
+            _, context = setup_protocol(
+                f.gantry_path,
+                f.deck_path,
+                f.board_path,
+                f.protocol_path,
+                collision_validation=True,
+            )
+
+            assert context.collision_report.ok
 
 
 class TestRunProtocolLifecycle:

--- a/tests/validation/test_collision_geometry.py
+++ b/tests/validation/test_collision_geometry.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from validation.collision import CollisionBox
+from gantry.gantry_config import WorkingVolume
+
+
+def test_boxes_intersect_with_positive_overlap() -> None:
+    a = CollisionBox(0, 10, 0, 10, 0, 10)
+    b = CollisionBox(5, 15, 5, 15, 5, 15)
+
+    assert a.intersects(b)
+    assert b.intersects(a)
+
+
+def test_touching_boundaries_do_not_intersect() -> None:
+    a = CollisionBox(0, 10, 0, 10, 0, 10)
+    b = CollisionBox(10, 20, 0, 10, 0, 10)
+
+    assert not a.intersects(b)
+    assert not a.overlaps_xy(b)
+
+
+def test_xy_overlap_is_independent_of_z_overlap() -> None:
+    a = CollisionBox(0, 10, 0, 10, 0, 10)
+    b = CollisionBox(5, 15, 5, 15, 20, 30)
+
+    assert a.overlaps_xy(b)
+    assert not a.intersects(b)
+
+
+def test_box_translation_preserves_size() -> None:
+    box = CollisionBox(0, 10, 1, 11, 2, 12)
+
+    moved = box.translated(3, 4, 5)
+
+    assert moved == CollisionBox(3, 13, 5, 15, 7, 17)
+
+
+def test_working_volume_containment() -> None:
+    volume = WorkingVolume(0, 20, 0, 20, 0, 20)
+
+    assert CollisionBox(1, 10, 1, 10, 1, 10).contained_by(volume)
+    assert not CollisionBox(-1, 10, 1, 10, 1, 10).contained_by(volume)
+
+
+def test_center_base_constructor_uses_base_z_and_xy_center() -> None:
+    box = CollisionBox.from_center_base(
+        center_x=10,
+        center_y=20,
+        base_z=5,
+        size_x=4,
+        size_y=6,
+        size_z=8,
+    )
+
+    assert box == CollisionBox(8, 12, 17, 23, 5, 13)

--- a/tests/validation/test_collision_validation.py
+++ b/tests/validation/test_collision_validation.py
@@ -1,0 +1,379 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from board.board import Board
+from deck.deck import Deck
+from deck.labware.labware import Coordinate3D
+from deck.labware.vial import Vial
+from deck.labware.well_plate import WellPlate
+from gantry.gantry_config import GantryConfig, HomingStrategy, WorkingVolume
+from protocol_engine.protocol import Protocol, ProtocolContext, ProtocolStep
+from validation.collision import (
+    CollisionBox,
+    CollisionSettings,
+    CollisionValidationMode,
+    build_labware_envelopes,
+    compute_required_safe_z,
+    extract_collision_poses,
+    instrument_envelope_at,
+    validate_collision_safety,
+)
+
+
+def _gantry(z_min: float = 0.0, z_max: float = 100.0) -> GantryConfig:
+    return GantryConfig(
+        serial_port="/dev/null",
+        homing_strategy=HomingStrategy.STANDARD,
+        total_z_height=120.0,
+        working_volume=WorkingVolume(0, 200, 0, 200, z_min, z_max),
+    )
+
+
+def _vial(name: str = "vial_1", x: float = 50.0, y: float = 50.0, z: float = 20.0) -> Vial:
+    return Vial(
+        name=name,
+        model_name="vial",
+        height_mm=10.0,
+        diameter_mm=10.0,
+        location=Coordinate3D(x=x, y=y, z=z),
+        capacity_ul=1000.0,
+        working_volume_ul=800.0,
+    )
+
+
+def _plate() -> WellPlate:
+    wells = {
+        "A1": Coordinate3D(x=20.0, y=20.0, z=5.0),
+        "A2": Coordinate3D(x=30.0, y=20.0, z=5.0),
+        "B1": Coordinate3D(x=20.0, y=30.0, z=5.0),
+        "B2": Coordinate3D(x=30.0, y=30.0, z=5.0),
+    }
+    return WellPlate(
+        name="plate",
+        model_name="plate",
+        length_mm=30.0,
+        width_mm=30.0,
+        height_mm=8.0,
+        rows=2,
+        columns=2,
+        wells=wells,
+    )
+
+
+def _instrument(
+    *,
+    name: str,
+    offset_x: float = 0.0,
+    offset_y: float = 0.0,
+    depth: float = 0.0,
+    measurement_height: float = 0.0,
+    origin_z: float = -12.0,
+    size_x: float = 4.0,
+    size_y: float = 4.0,
+    size_z: float = 4.0,
+):
+    instrument = MagicMock()
+    instrument.name = name
+    instrument.offset_x = offset_x
+    instrument.offset_y = offset_y
+    instrument.depth = depth
+    instrument.measurement_height = measurement_height
+    instrument.collision_geometry = {
+        "kind": "box",
+        "size": {"x": size_x, "y": size_y, "z": size_z},
+        "origin_offset": {"x": -size_x / 2, "y": -size_y / 2, "z": origin_z},
+    }
+    return instrument
+
+
+def _context(
+    *,
+    deck: Deck | None = None,
+    instruments: dict | None = None,
+    positions: dict | None = None,
+) -> ProtocolContext:
+    board = Board(gantry=MagicMock(), instruments=instruments or {
+        "pipette": _instrument(name="pipette"),
+    })
+    return ProtocolContext(
+        board=board,
+        deck=deck or Deck({"vial_1": _vial()}),
+        positions=positions or {},
+        gantry=_gantry(),
+    )
+
+
+def _protocol(*steps: ProtocolStep) -> Protocol:
+    return Protocol(list(steps))
+
+
+def _step(index: int, command: str, args: dict) -> ProtocolStep:
+    return ProtocolStep(index=index, command_name=command, handler=lambda *_args, **_kwargs: None, args=args)
+
+
+def test_vial_envelope_uses_diameter_and_height() -> None:
+    envelopes, report = build_labware_envelopes(Deck({"vial_1": _vial()}))
+
+    assert report.ok
+    assert envelopes[0].box == CollisionBox(45, 55, 45, 55, 20, 30)
+
+
+def test_well_plate_envelope_uses_well_spread_and_dimensions() -> None:
+    envelopes, report = build_labware_envelopes(Deck({"plate": _plate()}))
+
+    assert report.ok
+    assert envelopes[0].box == CollisionBox(10, 40, 10, 40, 5, 13)
+
+
+def test_missing_labware_geometry_warns_in_report_only() -> None:
+    plate = _plate()
+    plate.length_mm = None
+    plate.geometry.length_mm = None
+
+    _, report = build_labware_envelopes(
+        Deck({"plate": plate}),
+        settings=CollisionSettings(mode=CollisionValidationMode.REPORT_ONLY),
+    )
+
+    assert not report.errors
+    assert report.warnings[0].code == "missing_labware_geometry"
+
+
+def test_instrument_envelope_uses_board_offsets_and_depth() -> None:
+    instr = _instrument(
+        name="camera",
+        offset_x=10,
+        offset_y=20,
+        depth=5,
+        origin_z=1,
+        size_x=2,
+        size_y=4,
+        size_z=6,
+    )
+
+    envelope = instrument_envelope_at(
+        instrument_name="camera",
+        instrument=instr,
+        gantry_x=100,
+        gantry_y=50,
+        gantry_z=10,
+    )
+
+    assert envelope is not None
+    assert envelope.box == CollisionBox(109, 111, 68, 72, 16, 22)
+
+
+def test_move_pose_resolves_named_raw_and_deck_targets() -> None:
+    context = _context(positions={"safe": [1, 2, 3]})
+    protocol = _protocol(
+        _step(0, "move", {"instrument": "pipette", "position": "safe"}),
+        _step(1, "move", {"instrument": "pipette", "position": [4, 5, 6]}),
+        _step(2, "move", {"instrument": "pipette", "position": "vial_1"}),
+    )
+
+    poses, report = extract_collision_poses(protocol, context)
+
+    assert report.ok
+    assert [(p.target.x, p.target.y, p.target.z, p.target_key) for p in poses] == [
+        (1, 2, 3, None),
+        (4, 5, 6, None),
+        (50, 50, 20, "vial_1"),
+    ]
+
+
+def test_scan_and_measure_preserve_existing_measurement_height_signs() -> None:
+    plate = _plate()
+    context = _context(
+        deck=Deck({"plate": plate}),
+        instruments={"sensor": _instrument(name="sensor", measurement_height=2.0)},
+    )
+    protocol = _protocol(
+        _step(0, "scan", {"plate": "plate", "instrument": "sensor", "method": "measure"}),
+        _step(1, "measure", {"position": "plate.A1", "instrument": "sensor", "method": "measure"}),
+    )
+
+    poses, report = extract_collision_poses(protocol, context)
+
+    assert report.ok
+    assert [pose.target.z for pose in poses[:4]] == [3.0, 3.0, 3.0, 3.0]
+    assert poses[4].target.z == 7.0
+
+
+def test_transfer_extracts_source_and_destination() -> None:
+    context = _context(deck=Deck({"source": _vial("source", x=10), "dest": _vial("dest", x=90)}))
+    protocol = _protocol(_step(0, "transfer", {
+        "source": "source",
+        "destination": "dest",
+        "volume_ul": 10,
+    }))
+
+    poses, report = extract_collision_poses(protocol, context)
+
+    assert report.ok
+    assert [(pose.purpose, pose.target_key) for pose in poses] == [
+        ("source", "source"),
+        ("destination", "dest"),
+    ]
+
+
+def test_home_pause_and_breakpoint_are_collision_noops() -> None:
+    context = _context()
+    protocol = _protocol(
+        _step(0, "home", {}),
+        _step(1, "pause", {"seconds": 1}),
+        _step(2, "breakpoint", {}),
+    )
+
+    poses, report = extract_collision_poses(protocol, context)
+
+    assert poses == []
+    assert report.ok
+
+
+def test_strict_validation_fails_missing_instrument_geometry() -> None:
+    instr = _instrument(name="pipette")
+    instr.collision_geometry = None
+    context = _context(instruments={"pipette": instr})
+    protocol = _protocol(_step(0, "move", {"instrument": "pipette", "position": "vial_1"}))
+
+    report = validate_collision_safety(protocol, context, _gantry())
+
+    assert any(issue.code == "missing_instrument_geometry" for issue in report.errors)
+
+
+def test_report_only_missing_instrument_geometry_warns() -> None:
+    instr = _instrument(name="pipette")
+    instr.collision_geometry = None
+    context = _context(instruments={"pipette": instr})
+    protocol = _protocol(_step(0, "move", {"instrument": "pipette", "position": "vial_1"}))
+
+    report = validate_collision_safety(
+        protocol,
+        context,
+        _gantry(),
+        settings=CollisionSettings(mode=CollisionValidationMode.REPORT_ONLY),
+    )
+
+    assert not report.errors
+    assert any(issue.code == "missing_instrument_geometry" for issue in report.warnings)
+
+
+def test_non_active_side_mounted_instrument_collision_fails() -> None:
+    context = _context(instruments={
+        "pipette": _instrument(name="pipette", origin_z=12),
+        "camera": _instrument(name="camera", origin_z=0, size_x=12, size_y=12, size_z=5),
+    })
+    protocol = _protocol(_step(0, "move", {"instrument": "pipette", "position": "vial_1"}))
+
+    report = validate_collision_safety(protocol, context, _gantry())
+
+    assert any(
+        issue.code == "instrument_labware_collision"
+        and issue.body_a == "camera"
+        and issue.body_b == "vial_1"
+        for issue in report.errors
+    )
+
+
+def test_report_only_downgrades_collisions_to_warnings() -> None:
+    context = _context(instruments={
+        "pipette": _instrument(name="pipette", origin_z=-12),
+        "camera": _instrument(name="camera", origin_z=0, size_x=12, size_y=12, size_z=5),
+    })
+    protocol = _protocol(_step(0, "move", {"instrument": "pipette", "position": "vial_1"}))
+
+    report = validate_collision_safety(
+        protocol,
+        context,
+        _gantry(),
+        settings=CollisionSettings(mode=CollisionValidationMode.REPORT_ONLY),
+    )
+
+    assert report.ok
+    assert any(issue.code == "instrument_labware_collision" for issue in report.warnings)
+
+
+def test_xy_overlap_with_sufficient_z_clearance_passes() -> None:
+    context = _context(instruments={
+        "pipette": _instrument(name="pipette", origin_z=-12),
+        "camera": _instrument(name="camera", origin_z=-20, size_x=12, size_y=12, size_z=5),
+    })
+    protocol = _protocol(_step(0, "move", {"instrument": "pipette", "position": "vial_1"}))
+
+    report = validate_collision_safety(protocol, context, _gantry())
+
+    assert report.ok
+
+
+def test_required_safe_z_above_working_volume_fails() -> None:
+    context = _context(deck=Deck({"vial_1": _vial(z=1)}))
+    protocol = _protocol(_step(0, "move", {"instrument": "pipette", "position": "vial_1"}))
+
+    report = validate_collision_safety(protocol, context, _gantry(z_max=100))
+
+    assert compute_required_safe_z(build_labware_envelopes(context.deck)[0], clearance_mm=2) == -1
+    assert any(issue.code == "safe_z_out_of_volume" for issue in report.errors)
+
+
+def test_active_nested_target_does_not_exempt_parent_holder() -> None:
+    from deck.labware.vial_holder import VialHolder
+
+    child = _vial("vial_1", x=50.0, y=50.0, z=25.0)
+    holder = VialHolder(
+        name="holder",
+        model_name="holder",
+        location=Coordinate3D(x=50.0, y=50.0, z=20.0),
+        contained_labware={"vial_1": child},
+    )
+    context = _context(
+        deck=Deck({"holder": holder}),
+        instruments={"pipette": _instrument(name="pipette", origin_z=20, size_x=20, size_y=20, size_z=5)},
+    )
+    protocol = _protocol(_step(0, "move", {
+        "instrument": "pipette",
+        "position": "holder.vial_1",
+    }))
+
+    report = validate_collision_safety(protocol, context, _gantry())
+
+    assert any(
+        issue.code == "instrument_labware_collision"
+        and issue.body_a == "pipette"
+        and issue.body_b == "holder"
+        for issue in report.errors
+    )
+
+
+def test_active_nested_well_target_allows_child_plate_not_parent_holder() -> None:
+    from deck.labware.well_plate_holder import WellPlateHolder
+
+    holder = WellPlateHolder(
+        name="holder",
+        model_name="holder",
+        location=Coordinate3D(x=25.0, y=25.0, z=20.0),
+        contained_labware={"plate": _plate()},
+    )
+    context = _context(
+        deck=Deck({"holder": holder}),
+        instruments={"pipette": _instrument(name="pipette", origin_z=20, size_x=20, size_y=20, size_z=5)},
+    )
+    protocol = _protocol(_step(0, "move", {
+        "instrument": "pipette",
+        "position": "holder.plate.A1",
+    }))
+
+    report = validate_collision_safety(protocol, context, _gantry())
+
+    assert any(
+        issue.code == "instrument_labware_collision"
+        and issue.body_a == "pipette"
+        and issue.body_b == "holder"
+        for issue in report.errors
+    )
+    assert not any(
+        issue.code == "instrument_labware_collision"
+        and issue.body_a == "pipette"
+        and issue.body_b == "holder.plate"
+        for issue in report.errors
+    )


### PR DESCRIPTION
CubOS only checked addressable points against gantry bounds, which misses multi-instrument board collisions where a non-active attachment overlaps labware while the active instrument reaches its target. This adds an opt-in static collision validation gate around setup, using conservative envelopes, safe-Z clearance, and protocol pose extraction while preserving existing setup behavior by default.

Constraint: V1 must stay dependency-free and avoid optimizer, swept-path, full swept-volume, and separate vertical-column simulation behavior
Constraint: CubOS user-space Z is positive-down, so safe-Z clearance is computed upward from labware envelopes
Rejected: Runtime-only collision interception | it detects hazards too late for pre-run setup validation
Rejected: Third-party geometry engine | unnecessary for conservative V1 and new dependencies require explicit approval
Rejected: Prefix-only target allowance | nested holder targets could incorrectly exempt parent holders
Confidence: high
Scope-risk: moderate
Directive: Do not enable strict collision validation by default until production board configs include explicit collision_geometry
Tested: python -m pytest tests/validation/test_collision_geometry.py tests/validation/test_collision_validation.py tests/board/test_board_loader.py tests/setup/test_protocol_setup.py -q -> 77 passed
Tested: python -m pytest tests/protocol_engine -q -> 134 passed
Tested: python -m pytest -q -> 790 passed
Tested: python -m py_compile touched source modules
Tested: git diff --check
Not-tested: Hardware motion with real gantry and physical instruments