### PR TITLE
Remove stale mock.py references from docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,11 +75,11 @@ Driver for the Excelitas OmniCure S1500 PRO UV curing system over RS-232 serial.
 #### Pipette (`src/instruments/pipette`)
 Driver for Opentrons OT-2 and Flex pipettes. Communicates with the pipette motor via Arduino serial (Pawduino firmware). Supports 10 pipette models; the P300 single-channel has real calibrated values from the BEAR-DEN workcell.
 
-- **`driver.py`**: `Pipette(BaseInstrument)` — the real serial driver.
-    - **Constructor**: `Pipette(pipette_model, port, baud_rate=115200, command_timeout=30.0, name=None)`
+- **`driver.py`**: `Pipette(BaseInstrument)` — serial driver with built-in offline mode.
+    - **Constructor**: `Pipette(pipette_model, port, baud_rate=115200, command_timeout=30.0, name=None, offline=False)`
     - **Lifecycle**: `connect()`, `disconnect()`, `health_check()`, `warm_up()` (homes + primes)
     - **Commands**: `home()`, `prime(speed)`, `aspirate(volume_ul, speed)`, `dispense(volume_ul, speed)`, `blowout(speed)`, `mix(volume_ul, reps, speed)`, `pick_up_tip(speed)`, `drop_tip(speed)`, `get_status() -> PipetteStatus`, `drip_stop(volume_ul, speed)`
-- **`mock.py`**: `MockPipette` — in-memory mock for testing. Tracks `command_history: list[str]`.
+    - **Offline mode**: Pass `offline=True` for dry runs — simulates plunger state in memory without serial I/O.
 - **`models.py`**: `PipetteConfig` (frozen, per-model hardware description), `PipetteStatus`, `AspirateResult`, `MixResult` (all frozen dataclasses). `PIPETTE_MODELS` registry dict. `PipetteFamily` enum (OT2/FLEX).
 - **`exceptions.py`**: `PipetteError` hierarchy (`PipetteConnectionError`, `PipetteCommandError`, `PipetteTimeoutError`, `PipetteConfigError`).
 

--- a/src/instruments/README.md
+++ b/src/instruments/README.md
@@ -17,17 +17,18 @@ Every instrument folder follows the same layout:
 ```
 <instrument>/
 ├── __init__.py       # Public exports
-├── driver.py         # Real hardware driver (extends BaseInstrument)
-├── mock.py           # Mock implementation for testing (extends BaseInstrument)
+├── driver.py         # Hardware driver (extends BaseInstrument, supports offline=True)
 ├── models.py         # Frozen dataclasses for measurement results
 └── exceptions.py     # Instrument-specific exception hierarchy
 ```
+
+Drivers support an `offline=True` constructor flag for dry runs — no serial I/O, synthetic return values. The board loader passes `offline=True` automatically when `mock_mode=True`.
 
 ## Adding a new instrument
 
 1. Create a new folder under `src/instruments/`.
 2. Subclass `BaseInstrument` and implement `connect()`, `disconnect()`, `health_check()`.
-3. Add a mock that tracks `command_history` for test assertions.
+3. Guard all I/O with `if self._offline: ...` branches that return synthetic data.
 4. Define a frozen dataclass in `models.py` for measurement results.
 5. Create an exception hierarchy rooted in `InstrumentError`.
 6. Register the instrument in `registry.yaml` (type, module, class_name, vendors).


### PR DESCRIPTION
## Summary
- AGENTS.md no longer mentions \`MockPipette\` / \`mock.py\` — replaced with the actual \`offline=True\` pattern
- instruments/README.md updated: removed \`mock.py\` from the folder layout, added guidance to guard I/O with \`if self._offline\` branches when adding new instruments
- No code changes — all instruments already use the consistent offline flag

## Why
Docs were out of date: \`MockPipette\` and per-instrument \`mock.py\` files don't exist in the repo. The current pattern is a single driver class with a built-in \`offline=True\` constructor flag, applied uniformly across pipette, uvvis_ccs, asmi, filmetrics, and uv_curing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)