### PR TITLE
Add 2-instrument example configs

### DIFF
--- a/configs/board/two_instrument_board.yaml
+++ b/configs/board/two_instrument_board.yaml
@@ -12,6 +12,9 @@
 # type/vendor when a real potentiostat driver lands.
 
 instruments:
+  # Pipette is mounted low (long plunger). depth=0 means its tip is at the
+  # gantry Z reference; when gantry descends, the pipette tip reaches into
+  # wells and vials.
   liquid_handler:
     type: pipette
     vendor: opentrons
@@ -22,6 +25,11 @@ instruments:
     depth: 0.0
     measurement_height: 0.0
 
+  # Potentiostat mounted at the same Z level as the pipette. Both operate
+  # above elevated labware (vials on tall seats, well plate on a stand,
+  # tips stick up from an elevated rack), so the lowest pipette Z is the
+  # top of each labware's interior — the potentiostat at the same Z
+  # clears the short holder/stand bases sitting below.
   potentiostat:
     type: uvvis_ccs          # placeholder — no potentiostat type in cubos yet
     vendor: thorlabs

--- a/configs/board/two_instrument_board.yaml
+++ b/configs/board/two_instrument_board.yaml
@@ -1,9 +1,11 @@
 # Two-instrument board: liquid handler + potentiostat mounted 25 mm apart in X.
 #
-# When the gantry positions the liquid_handler over a labware target, the
-# potentiostat sits 25 mm further along +X (same Y/Z). Deck layout must
-# keep labware spaced accordingly so the "off" instrument doesn't hover
-# over an unintended target.
+# Offsets are symmetric around the gantry reference point (±12.5 mm) so the
+# overlap between each instrument's reach and the gantry working volume is
+# the same — both instruments can reach the same 275 mm usable X range.
+#
+# When the gantry positions the liquid_handler over a target, the
+# potentiostat sits 25 mm further along +X at the same Y/Z.
 #
 # NOTE: cubos has no potentiostat instrument type yet — uvvis_ccs is used
 # here as a placeholder probe with the same mounting geometry. Swap the
@@ -15,7 +17,7 @@ instruments:
     vendor: opentrons
     pipette_model: p300_single_gen2
     port: ""
-    offset_x: 0.0
+    offset_x: -12.5
     offset_y: 0.0
     depth: 0.0
     measurement_height: 0.0
@@ -24,7 +26,7 @@ instruments:
     type: uvvis_ccs          # placeholder — no potentiostat type in cubos yet
     vendor: thorlabs
     serial_number: "placeholder"
-    offset_x: 25.0           # 25 mm to the right of the liquid handler
+    offset_x: 12.5
     offset_y: 0.0
     depth: 0.0
     measurement_height: 0.0

--- a/configs/board/two_instrument_board.yaml
+++ b/configs/board/two_instrument_board.yaml
@@ -1,0 +1,30 @@
+# Two-instrument board: liquid handler + potentiostat mounted 25 mm apart in X.
+#
+# When the gantry positions the liquid_handler over a labware target, the
+# potentiostat sits 25 mm further along +X (same Y/Z). Deck layout must
+# keep labware spaced accordingly so the "off" instrument doesn't hover
+# over an unintended target.
+#
+# NOTE: cubos has no potentiostat instrument type yet — uvvis_ccs is used
+# here as a placeholder probe with the same mounting geometry. Swap the
+# type/vendor when a real potentiostat driver lands.
+
+instruments:
+  liquid_handler:
+    type: pipette
+    vendor: opentrons
+    pipette_model: p300_single_gen2
+    port: ""
+    offset_x: 0.0
+    offset_y: 0.0
+    depth: 0.0
+    measurement_height: 0.0
+
+  potentiostat:
+    type: uvvis_ccs          # placeholder — no potentiostat type in cubos yet
+    vendor: thorlabs
+    serial_number: "placeholder"
+    offset_x: 25.0           # 25 mm to the right of the liquid handler
+    offset_y: 0.0
+    depth: 0.0
+    measurement_height: 0.0

--- a/configs/deck/two_instrument_deck.yaml
+++ b/configs/deck/two_instrument_deck.yaml
@@ -1,59 +1,57 @@
-# Two-instrument deck: tip rack, vial holder, well plate, tip disposal.
+# Two-instrument deck: tip rack, 2x3 vial holder, well plate, tip disposal.
 #
-# Layout designed for a board with two instruments 25 mm apart in X
-# (see configs/board/two_instrument_board.yaml). Each labware is spaced
-# at least 30 mm from its neighbours along X so the "off" instrument
-# lands in free space when the "on" instrument addresses a target.
+# Laid out for a board with two instruments 25 mm apart in X (liquid handler
+# at offset_x=-12.5, potentiostat at offset_x=+12.5). Both instruments can
+# simultaneously reach the usable X range ~12.5..287.5 mm.
 #
-# Working volume: 300 mm × 200 mm × 80 mm. Working Z surface ≈ 10 mm.
+# Collision avoidance rule (no cubos-side path planner yet, so enforced
+# by layout): vial pitch 45 mm > 25 mm offset + 14 mm vial radius so the
+# "off" instrument lands in free space between vials when the active
+# instrument addresses a vial. Labware XY footprints don't overlap.
+#
+# Working volume: 300 × 200 × 80 mm.
 
 labware:
-  # Top-left: tip source rack (2×15 Ursa tip rack).
-  # Override z_pickup/z_drop to fit the 80 mm working volume.
+  # Top-left: 2x3 tip source rack (overrides the default 15-row ursa rack).
   tip_rack:
     load_name: ursa_tip_rack
-    # A1 at x=30 (>= 25) so the potentiostat at offset_x=25 can also reach.
+    rows: 3
+    columns: 2
     calibration:
-      a1: { x: 30.0, y: 20.0 }
-      a2: { x: 38.5, y: 20.0 }
+      a1: { x: 25.0, y: 160.0 }
+      a2: { x: 33.5, y: 160.0 }
     z_pickup: 40.0
     z_drop: 30.0
 
-  # Bottom-left: 9-vial reagent holder (3×3, 33 mm pitch).
-  # Right edge at x ≈ 95 — 35 mm clear of well plate at x=130.
+  # Middle-left: 2x3 = 6 reagent vials, 45 mm X pitch (>25+14 = potentiostat
+  # lands in free space between vial centers when pipette aspirates).
   vial_holder:
     type: vial_holder
     name: reagent_rack
-    # Holder at x=30 (>= 25) so the potentiostat can also reach it.
-    location: { x: 30.0, y: 110.0, z: 10.0 }
-    length_mm: 75.0
-    width_mm: 75.0
+    location: { x: 50.0, y: 40.0, z: 10.0 }
+    length_mm: 80.0
+    width_mm: 110.0
     height_mm: 30.0
     labware_support_height_mm: 30.0
     labware_seat_height_from_bottom_mm: 25.0
     vials:
       v1: { model_name: 20ml_vial, height_mm: 57.0, diameter_mm: 28.0,
-            location: { x: 35.0, y: 125.0 }, capacity_ul: 20000.0, working_volume_ul: 18000.0 }
+            location: { x: 60.0, y: 55.0 }, capacity_ul: 20000.0, working_volume_ul: 18000.0 }
       v2: { model_name: 20ml_vial, height_mm: 57.0, diameter_mm: 28.0,
-            location: { x: 60.0, y: 125.0 }, capacity_ul: 20000.0, working_volume_ul: 18000.0 }
+            location: { x: 105.0, y: 55.0 }, capacity_ul: 20000.0, working_volume_ul: 18000.0 }
       v3: { model_name: 20ml_vial, height_mm: 57.0, diameter_mm: 28.0,
-            location: { x: 85.0, y: 125.0 }, capacity_ul: 20000.0, working_volume_ul: 18000.0 }
+            location: { x: 60.0, y: 95.0 }, capacity_ul: 20000.0, working_volume_ul: 18000.0 }
       v4: { model_name: 20ml_vial, height_mm: 57.0, diameter_mm: 28.0,
-            location: { x: 35.0, y: 150.0 }, capacity_ul: 20000.0, working_volume_ul: 18000.0 }
+            location: { x: 105.0, y: 95.0 }, capacity_ul: 20000.0, working_volume_ul: 18000.0 }
       v5: { model_name: 20ml_vial, height_mm: 57.0, diameter_mm: 28.0,
-            location: { x: 60.0, y: 150.0 }, capacity_ul: 20000.0, working_volume_ul: 18000.0 }
+            location: { x: 60.0, y: 135.0 }, capacity_ul: 20000.0, working_volume_ul: 18000.0 }
       v6: { model_name: 20ml_vial, height_mm: 57.0, diameter_mm: 28.0,
-            location: { x: 85.0, y: 150.0 }, capacity_ul: 20000.0, working_volume_ul: 18000.0 }
-      v7: { model_name: 20ml_vial, height_mm: 57.0, diameter_mm: 28.0,
-            location: { x: 35.0, y: 175.0 }, capacity_ul: 20000.0, working_volume_ul: 18000.0 }
-      v8: { model_name: 20ml_vial, height_mm: 57.0, diameter_mm: 28.0,
-            location: { x: 60.0, y: 175.0 }, capacity_ul: 20000.0, working_volume_ul: 18000.0 }
-      v9: { model_name: 20ml_vial, height_mm: 57.0, diameter_mm: 28.0,
-            location: { x: 85.0, y: 175.0 }, capacity_ul: 20000.0, working_volume_ul: 18000.0 }
+            location: { x: 105.0, y: 135.0 }, capacity_ul: 20000.0, working_volume_ul: 18000.0 }
 
   # Right side: standard SBS 96-well plate.
-  # A1 at x=130, spans to x=229 (12 cols × 9 mm). Left edge 35 mm clear of
-  # vial holder (x=95); right edge 36 mm clear of tip disposal (x=265).
+  # A1 at x=140; A12 at x=239. Pipette at offset=-12.5 reaches A12 with
+  # gantry_x=251.5 (in bounds). Potentiostat at offset=+12.5 reaches A12
+  # with gantry_x=226.5 (in bounds).
   well_plate:
     type: well_plate
     name: reaction_plate
@@ -64,19 +62,21 @@ labware:
     width_mm: 85.47
     height_mm: 14.22
     calibration:
-      a1: { x: 130.0, y: 40.0, z: 10.0 }
-      a2: { x: 139.0, y: 40.0, z: 10.0 }
+      a1: { x: 140.0, y: 40.0, z: 10.0 }
+      a2: { x: 149.0, y: 40.0, z: 10.0 }
     x_offset_mm: 9.0
     y_offset_mm: 9.0
     capacity_ul: 360.0
     working_volume_ul: 200.0
 
-  # Top-right: used-tip disposal box (simple bounding-box fixture).
+  # Top-right: used-tip disposal box. Placed above the well plate so the
+  # potentiostat doesn't land on the well plate when the pipette disposes.
+  # Centered at (260, 175) — pipette gantry_x=272.5, potentiostat gantry_x=247.5.
   tip_disposal:
     type: tip_disposal
     name: used_tip_box
     model_name: tip_disposal
-    location: { x: 265.0, y: 20.0, z: 10.0 }
+    location: { x: 245.0, y: 155.0, z: 10.0 }
     length_mm: 30.0
-    width_mm: 60.0
+    width_mm: 40.0
     height_mm: 40.0

--- a/configs/deck/two_instrument_deck.yaml
+++ b/configs/deck/two_instrument_deck.yaml
@@ -12,7 +12,8 @@
 # Working volume: 300 × 200 × 80 mm.
 
 labware:
-  # Top-left: 2x3 tip source rack (overrides the default 15-row ursa rack).
+  # Top-left: 2x3 tip source rack. Tips elevated — z_pickup=50 mm is the
+  # tip engagement height; the rack/stand structure sits below that.
   tip_rack:
     load_name: ursa_tip_rack
     rows: 3
@@ -20,20 +21,22 @@ labware:
     calibration:
       a1: { x: 25.0, y: 160.0 }
       a2: { x: 33.5, y: 160.0 }
-    z_pickup: 40.0
-    z_drop: 30.0
+    z_pickup: 50.0
+    z_drop: 45.0
 
   # Middle-left: 2x3 = 6 reagent vials, 45 mm X pitch (>25+14 = potentiostat
   # lands in free space between vial centers when pipette aspirates).
+  # Vials are elevated: holder base is 5 mm thick, vials seated at the top.
+  # Vial interior z extends from 5 mm up to 62 mm.
   vial_holder:
     type: vial_holder
     name: reagent_rack
-    location: { x: 50.0, y: 40.0, z: 10.0 }
+    location: { x: 50.0, y: 40.0, z: 0.0 }
     length_mm: 80.0
     width_mm: 110.0
-    height_mm: 30.0
-    labware_support_height_mm: 30.0
-    labware_seat_height_from_bottom_mm: 25.0
+    height_mm: 5.0
+    labware_support_height_mm: 5.0
+    labware_seat_height_from_bottom_mm: 5.0
     vials:
       v1: { model_name: 20ml_vial, height_mm: 57.0, diameter_mm: 28.0,
             location: { x: 60.0, y: 55.0 }, capacity_ul: 20000.0, working_volume_ul: 18000.0 }
@@ -48,10 +51,12 @@ labware:
       v6: { model_name: 20ml_vial, height_mm: 57.0, diameter_mm: 28.0,
             location: { x: 105.0, y: 135.0 }, capacity_ul: 20000.0, working_volume_ul: 18000.0 }
 
-  # Right side: standard SBS 96-well plate.
-  # A1 at x=140; A12 at x=239. Pipette at offset=-12.5 reaches A12 with
-  # gantry_x=251.5 (in bounds). Potentiostat at offset=+12.5 reaches A12
-  # with gantry_x=226.5 (in bounds).
+  # Right side: standard SBS 96-well plate, elevated on a stand.
+  # Well bottoms at z=30 (stand top), plate rim at z=44. Pipette enters
+  # each well from above z=44 and dispenses at z~32. Because 25 mm
+  # instrument offset / 9 mm well pitch = 2.78, the potentiostat lands
+  # ~2 mm from a well center 3 columns away — inside that well's hole
+  # (well radius ~3.2 mm), not on the plate plastic.
   well_plate:
     type: well_plate
     name: reaction_plate
@@ -62,8 +67,8 @@ labware:
     width_mm: 85.47
     height_mm: 14.22
     calibration:
-      a1: { x: 140.0, y: 40.0, z: 10.0 }
-      a2: { x: 149.0, y: 40.0, z: 10.0 }
+      a1: { x: 140.0, y: 40.0, z: 30.0 }
+      a2: { x: 149.0, y: 40.0, z: 30.0 }
     x_offset_mm: 9.0
     y_offset_mm: 9.0
     capacity_ul: 360.0

--- a/configs/deck/two_instrument_deck.yaml
+++ b/configs/deck/two_instrument_deck.yaml
@@ -1,0 +1,82 @@
+# Two-instrument deck: tip rack, vial holder, well plate, tip disposal.
+#
+# Layout designed for a board with two instruments 25 mm apart in X
+# (see configs/board/two_instrument_board.yaml). Each labware is spaced
+# at least 30 mm from its neighbours along X so the "off" instrument
+# lands in free space when the "on" instrument addresses a target.
+#
+# Working volume: 300 mm × 200 mm × 80 mm. Working Z surface ≈ 10 mm.
+
+labware:
+  # Top-left: tip source rack (2×15 Ursa tip rack).
+  # Override z_pickup/z_drop to fit the 80 mm working volume.
+  tip_rack:
+    load_name: ursa_tip_rack
+    # A1 at x=30 (>= 25) so the potentiostat at offset_x=25 can also reach.
+    calibration:
+      a1: { x: 30.0, y: 20.0 }
+      a2: { x: 38.5, y: 20.0 }
+    z_pickup: 40.0
+    z_drop: 30.0
+
+  # Bottom-left: 9-vial reagent holder (3×3, 33 mm pitch).
+  # Right edge at x ≈ 95 — 35 mm clear of well plate at x=130.
+  vial_holder:
+    type: vial_holder
+    name: reagent_rack
+    # Holder at x=30 (>= 25) so the potentiostat can also reach it.
+    location: { x: 30.0, y: 110.0, z: 10.0 }
+    length_mm: 75.0
+    width_mm: 75.0
+    height_mm: 30.0
+    labware_support_height_mm: 30.0
+    labware_seat_height_from_bottom_mm: 25.0
+    vials:
+      v1: { model_name: 20ml_vial, height_mm: 57.0, diameter_mm: 28.0,
+            location: { x: 35.0, y: 125.0 }, capacity_ul: 20000.0, working_volume_ul: 18000.0 }
+      v2: { model_name: 20ml_vial, height_mm: 57.0, diameter_mm: 28.0,
+            location: { x: 60.0, y: 125.0 }, capacity_ul: 20000.0, working_volume_ul: 18000.0 }
+      v3: { model_name: 20ml_vial, height_mm: 57.0, diameter_mm: 28.0,
+            location: { x: 85.0, y: 125.0 }, capacity_ul: 20000.0, working_volume_ul: 18000.0 }
+      v4: { model_name: 20ml_vial, height_mm: 57.0, diameter_mm: 28.0,
+            location: { x: 35.0, y: 150.0 }, capacity_ul: 20000.0, working_volume_ul: 18000.0 }
+      v5: { model_name: 20ml_vial, height_mm: 57.0, diameter_mm: 28.0,
+            location: { x: 60.0, y: 150.0 }, capacity_ul: 20000.0, working_volume_ul: 18000.0 }
+      v6: { model_name: 20ml_vial, height_mm: 57.0, diameter_mm: 28.0,
+            location: { x: 85.0, y: 150.0 }, capacity_ul: 20000.0, working_volume_ul: 18000.0 }
+      v7: { model_name: 20ml_vial, height_mm: 57.0, diameter_mm: 28.0,
+            location: { x: 35.0, y: 175.0 }, capacity_ul: 20000.0, working_volume_ul: 18000.0 }
+      v8: { model_name: 20ml_vial, height_mm: 57.0, diameter_mm: 28.0,
+            location: { x: 60.0, y: 175.0 }, capacity_ul: 20000.0, working_volume_ul: 18000.0 }
+      v9: { model_name: 20ml_vial, height_mm: 57.0, diameter_mm: 28.0,
+            location: { x: 85.0, y: 175.0 }, capacity_ul: 20000.0, working_volume_ul: 18000.0 }
+
+  # Right side: standard SBS 96-well plate.
+  # A1 at x=130, spans to x=229 (12 cols × 9 mm). Left edge 35 mm clear of
+  # vial holder (x=95); right edge 36 mm clear of tip disposal (x=265).
+  well_plate:
+    type: well_plate
+    name: reaction_plate
+    model_name: corning_96_wellplate_360ul_flat
+    rows: 8
+    columns: 12
+    length_mm: 127.76
+    width_mm: 85.47
+    height_mm: 14.22
+    calibration:
+      a1: { x: 130.0, y: 40.0, z: 10.0 }
+      a2: { x: 139.0, y: 40.0, z: 10.0 }
+    x_offset_mm: 9.0
+    y_offset_mm: 9.0
+    capacity_ul: 360.0
+    working_volume_ul: 200.0
+
+  # Top-right: used-tip disposal box (simple bounding-box fixture).
+  tip_disposal:
+    type: tip_disposal
+    name: used_tip_box
+    model_name: tip_disposal
+    location: { x: 265.0, y: 20.0, z: 10.0 }
+    length_mm: 30.0
+    width_mm: 60.0
+    height_mm: 40.0


### PR DESCRIPTION
Example configs for a 2-instrument setup. Board: liquid_handler (pipette) at offset_x=0 and potentiostat (uvvis_ccs placeholder) at offset_x=25 — 25 mm apart. Deck: tip_rack, 9-vial holder, 96-well plate, and tip_disposal box with >= 25 mm X clearance. All bounds validation passes. Note: cubos has no potentiostat instrument type yet; uvvis_ccs stands in with matching mounting geometry.