### PR TITLE
Add safe_approach_height to every instrument

### DIFF
--- a/src/board/yaml_schema.py
+++ b/src/board/yaml_schema.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Dict
+from typing import Dict, Optional
 
 from pydantic import BaseModel, ConfigDict
 
@@ -12,6 +12,13 @@ class InstrumentYamlEntry(BaseModel):
 
     Common fields are declared explicitly. Driver-specific fields
     (e.g. serial_number, dll_path) pass through via extra="allow".
+
+    Z-offset semantics (see BaseInstrument docstring for the full
+    explanation):
+      * ``measurement_height`` — Z offset during measurement/action.
+      * ``safe_approach_height`` — Z offset during XY travel (defaults
+        to ``measurement_height`` when omitted; set explicitly for
+        contact instruments like pipette/asmi/potentiostat).
     """
 
     model_config = ConfigDict(extra="allow")
@@ -22,6 +29,7 @@ class InstrumentYamlEntry(BaseModel):
     offset_y: float = 0.0
     depth: float = 0.0
     measurement_height: float = 0.0
+    safe_approach_height: Optional[float] = None
 
 
 class BoardYamlSchema(BaseModel):

--- a/src/instruments/asmi/driver.py
+++ b/src/instruments/asmi/driver.py
@@ -32,6 +32,7 @@ class ASMI(BaseInstrument):
         offset_y: float = 0.0,
         depth: float = 0.0,
         measurement_height: float = 0.0,
+        safe_approach_height: Optional[float] = None,
         offline: bool = False,  # passed through to BaseInstrument
         default_force: float = 0.0,
         force_threshold: float = _DEFAULT_FORCE_THRESHOLD,
@@ -47,6 +48,7 @@ class ASMI(BaseInstrument):
         super().__init__(
             name=name, offset_x=offset_x, offset_y=offset_y,
             depth=depth, measurement_height=measurement_height,
+            safe_approach_height=safe_approach_height,
             offline=offline,
         )
         self._default_force = default_force

--- a/src/instruments/base_instrument.py
+++ b/src/instruments/base_instrument.py
@@ -14,6 +14,20 @@ class BaseInstrument(ABC):
     All instruments accept an ``offline`` flag. When True, connect/disconnect
     are no-ops, health_check returns True, and instrument-specific methods
     return synthetic data without touching hardware.
+
+    Z-offset convention
+    -------------------
+    * ``measurement_height`` — Z offset applied when the instrument is
+      taking its measurement/action at a target. Non-contact instruments
+      (uvvis, filmetrics, uv_curing) use a small positive value for probe
+      clearance above the sample. Contact instruments (pipette, asmi,
+      potentiostat) use 0 (touch) or negative (dip into the sample).
+    * ``safe_approach_height`` — Z offset used while traveling above
+      labware toward a target, kept high enough to clear obstacles during
+      XY motion. For non-contact instruments this defaults to
+      ``measurement_height`` (no approach danger). For contact
+      instruments it should be explicitly set to a positive value so
+      the tip/probe doesn't drag through labware during travel.
     """
 
     def __init__(
@@ -23,6 +37,7 @@ class BaseInstrument(ABC):
         offset_y: float = 0.0,
         depth: float = 0.0,
         measurement_height: float = 0.0,
+        safe_approach_height: Optional[float] = None,
         offline: bool = False,
     ):
         self.name = name or self.__class__.__name__
@@ -30,6 +45,11 @@ class BaseInstrument(ABC):
         self.offset_y = offset_y
         self.depth = depth
         self.measurement_height = measurement_height
+        # If not specified, safe_approach_height falls back to measurement_height —
+        # correct for non-contact instruments where the two are equal.
+        self.safe_approach_height = (
+            safe_approach_height if safe_approach_height is not None else measurement_height
+        )
         self._offline = offline
         self.logger = logging.getLogger(f"{__name__}.{self.name}")
 

--- a/src/instruments/filmetrics/driver.py
+++ b/src/instruments/filmetrics/driver.py
@@ -33,6 +33,7 @@ class Filmetrics(BaseInstrument):
         offset_y: float = 0.0,
         depth: float = 0.0,
         measurement_height: float = 0.0,
+        safe_approach_height: Optional[float] = None,
         offline: bool = False,
         default_thickness_nm: float = 150.0,
         default_goodness_of_fit: float = 0.95,
@@ -41,6 +42,7 @@ class Filmetrics(BaseInstrument):
         super().__init__(
             name=name, offset_x=offset_x, offset_y=offset_y,
             depth=depth, measurement_height=measurement_height,
+            safe_approach_height=safe_approach_height,
             offline=offline,
         )
         self._exe_path = exe_path

--- a/src/instruments/pipette/driver.py
+++ b/src/instruments/pipette/driver.py
@@ -47,12 +47,14 @@ class Pipette(BaseInstrument):
         offset_y: float = 0.0,
         depth: float = 0.0,
         measurement_height: float = 0.0,
+        safe_approach_height: Optional[float] = None,
         offline: bool = False,
         **kwargs,
     ):
         super().__init__(
             name=name, offset_x=offset_x, offset_y=offset_y,
             depth=depth, measurement_height=measurement_height,
+            safe_approach_height=safe_approach_height,
             offline=offline,
         )
         if pipette_model not in PIPETTE_MODELS:

--- a/src/instruments/uv_curing/driver.py
+++ b/src/instruments/uv_curing/driver.py
@@ -53,12 +53,14 @@ class UVCuring(BaseInstrument):
         offset_y: float = 0.0,
         depth: float = 0.0,
         measurement_height: float = 0.0,
+        safe_approach_height: Optional[float] = None,
         offline: bool = False,
         **kwargs,
     ):
         super().__init__(
             name=name, offset_x=offset_x, offset_y=offset_y,
             depth=depth, measurement_height=measurement_height,
+            safe_approach_height=safe_approach_height,
             offline=offline,
         )
         self._port = port

--- a/src/instruments/uvvis_ccs/driver.py
+++ b/src/instruments/uvvis_ccs/driver.py
@@ -45,12 +45,14 @@ class UVVisCCS(BaseInstrument):
         offset_y: float = 0.0,
         depth: float = 0.0,
         measurement_height: float = 0.0,
+        safe_approach_height: Optional[float] = None,
         offline: bool = False,
         **kwargs,
     ):
         super().__init__(
             name=name, offset_x=offset_x, offset_y=offset_y,
             depth=depth, measurement_height=measurement_height,
+            safe_approach_height=safe_approach_height,
             offline=offline,
         )
         self._serial_number = serial_number


### PR DESCRIPTION
## Summary
Adds a uniform \`safe_approach_height\` attribute alongside \`measurement_height\` to every instrument. No behavior change yet — future commits will wire this into the move/measure commands.

### Z-offset convention
- \`measurement_height\` — Z offset while the instrument is taking its measurement/action.
  - Non-contact (uvvis, filmetrics, uv_curing): small positive value (probe clearance above sample)
  - Contact (pipette, asmi, potentiostat): 0 or negative (touch or dip into sample)
- \`safe_approach_height\` — Z offset while traveling above labware toward the target.
  - Non-contact: defaults to \`measurement_height\` (no approach danger)
  - Contact: should be explicitly set to a positive value so the tip doesn't drag through labware

### Changes
- \`BaseInstrument\`: new \`safe_approach_height\` kwarg; falls back to \`measurement_height\` when \`None\`
- Driver constructors updated: pipette, asmi, filmetrics, uv_curing, uvvis_ccs
- \`InstrumentYamlEntry\`: new optional \`safe_approach_height\` field

### Followups (separate PRs)
- Use \`safe_approach_height\` during XY travel in the move/measure commands
- Add to the potentiostat driver (currently on its own branch)

## Test plan
- [x] Existing tests pass (140/141; the unrelated sdist-metadata test still fails on the staging baseline)
- [x] YAML roundtrip: non-contact with only \`measurement_height\` set → \`safe_approach_height\` equals \`measurement_height\`; contact with both set → both preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)