### PR TITLE
Add dual indentation (measure_with_return) to ASMI

### DIFF
--- a/configs/protocol/asmi_indentation.yaml
+++ b/configs/protocol/asmi_indentation.yaml
@@ -29,6 +29,7 @@ protocol:
         force_limit: 10.0
         measurement_height: -73.0
         baseline_samples: 10
+        measure_with_return: false
 
   # Return to safe Z after scan
   - move:

--- a/docs/board.md
+++ b/docs/board.md
@@ -84,7 +84,7 @@ Vernier GoDirect force sensor for indentation measurements.
 | Method | Description |
 |--------|-------------|
 | `measure(n_samples)` | Take force readings. |
-| `indentation(gantry, z_limit, step_size, force_limit, measurement_height, baseline_samples)` | Step-by-step indentation: descend in Z steps, reading force at each step until force limit or Z limit. |
+| `indentation(gantry, z_limit, step_size, force_limit, measurement_height, baseline_samples, measure_with_return=False)` | Step-by-step indentation: descend in Z steps, reading force at each step until force limit or Z limit. Pass `measure_with_return=True` to also record upward return samples; every measurement carries a `direction` tag (`"down"` or `"up"`). |
 | `get_force_reading()` | Single instantaneous force reading. |
 | `get_baseline_force(samples)` | Average force over N samples (returns mean and std). |
 | `get_status()` | Return sensor state. |

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -33,6 +33,7 @@ protocol:
         force_limit: 10.0
         measurement_height: -73.0
         baseline_samples: 10
+        measure_with_return: false  # true = down + return (up) sampling
 
   # Return to safe Z after scan
   - move:

--- a/progress/2026-04-15.md
+++ b/progress/2026-04-15.md
@@ -1,0 +1,106 @@
+# 2026-04-15 — ASMI dual indentation PR review fixes
+
+## Context
+
+Branch: `feat/asmi-dual-indentation-protocol`. This feature adds a
+`measure_with_return` flag to `ASMI.indentation` so that after descending to
+`z_limit`, the instrument also records upward samples back to
+`measurement_height`, tagging each sample with `direction="down"` or `"up"`.
+Goal is to align CubOS with the dual-indentation functionality on the
+asmi-new main branch.
+
+Ran `/pr-review-toolkit:review-pr` first. Four agents (code-reviewer,
+pr-test-analyzer, silent-failure-hunter, comment-analyzer) flagged a mix of
+critical loop-safety issues, schema inconsistencies, and test gaps.
+
+## Work done
+
+All fixes below implemented against the unstaged working-tree changes.
+
+### Driver (`src/instruments/asmi/driver.py`)
+
+- Added `_step_count_bound(z_upper, z_lower, step_size)` helper at module
+  scope. Returns an upper bound on the number of steps required to cross a
+  Z span, with a safety margin. Raises `ValueError` if `step_size <= 0`.
+- Replaced the online descent `while True` with a `for _ in range(max_steps)`
+  bounded by `_step_count_bound`. Added `else:` clause logging a warning if
+  the cap is hit before reaching `z_target`.
+- Replaced the online return `while True` with the same bounded loop. Added
+  an in-loop guard: if `gantry.get_coordinates()` shows Z did not advance
+  after a `move_to`, log a warning and break (stall detection). This is
+  what prevented the original code from terminating when the gantry refused
+  to move.
+- Made `direction` unconditional on every sample in both online and offline
+  paths. Previously it was only emitted when `measure_with_return=True`,
+  producing heterogeneous dicts.
+- Added an info log when the return sweep starts (observability request
+  from review).
+- Rewrote offline descent/return as integer-indexed `for` loops (`range(1,
+  n+1)` with `max(..., z_limit)` / `min(..., measurement_height)` clamps).
+  Eliminates the float-accumulation drift the review flagged.
+- Tightened the `indentation` docstring to describe the return target,
+  every sample being tagged, and the full return-value schema.
+
+Per the user's guidance ("return force is less than downward force") we did
+**not** add a force-limit check to the return stroke. Descent force check
+is unchanged.
+
+### Normalizer (`src/protocol_engine/measurements.py`)
+
+- Added a warning log when `direction` tags are present on only *some*
+  steps. This catches mid-run corruption where part of a return sweep was
+  lost. Legacy fully-untagged payloads remain silent; the default to
+  `"down"` for missing entries is preserved.
+
+### Tests
+
+- `tests/instruments/test_asmi.py`:
+  - Migrated the existing indentation tests to pass overrides via kwargs
+    (`z_limit=`, `measurement_height=`, `step_size=`) instead of mutating
+    private attributes.
+  - `test_indentation_offline_emits_direction_unconditionally`: every
+    sample carries `direction="down"` even without return mode.
+  - `test_indentation_offline_return_preserves_ordering_and_monotonicity`:
+    all `down` samples precede all `up` samples; descent Z is strictly
+    decreasing, return Z strictly increasing, return terminates exactly at
+    `measurement_height`.
+  - `test_indentation_offline_return_no_float_drift`: step_size that does
+    not evenly divide the range still terminates cleanly at
+    `measurement_height`.
+  - New `TestASMIOnlineIndentation` class covers the `_offline=False` path
+    for the first time, using a minimal `_FakeOnlineGantry` stub plus
+    `mock.patch.object` on `get_force_reading` / `get_baseline_force`.
+    Two tests: happy path with both directions recorded, and a
+    stall-simulating gantry that would previously have spun forever.
+- `tests/protocol_engine/test_measurements.py`:
+  - `test_normalize_asmi_partial_direction_defaults_missing_to_down`:
+    mixed-tag step lists coerce missing entries to `"down"`.
+
+### Docs
+
+- `docs/board.md`: changed `measure_with_return=true` (YAML-style) to
+  `True` in the Python-signature table entry and expanded the description
+  to note that every measurement carries a `direction` tag.
+- `docs/protocol.md`: unchanged — the YAML example already uses lowercase
+  `false` correctly.
+
+## Issues found and how resolved
+
+- **Stall test hung on first run.** Confirms the infinite-loop bug the
+  review flagged. Added `pytest-timeout` (`--timeout=10`) to the test
+  environment to catch future regressions fast, and the fix (iteration cap
+  plus stall-break in the return loop) resolves it cleanly.
+- **Python 3.9 venv checked in at `venv/` cannot run the codebase** (pipe
+  syntax `float | None` requires 3.10+). Built a fresh 3.11 venv at
+  `/tmp/cubos-venv-311` for test execution only; no repo changes.
+
+## Test results
+
+- `pytest tests/instruments/test_asmi.py tests/protocol_engine/test_measurements.py --timeout=10` →  24 passed.
+- Full suite `pytest --timeout=30` → **875 passed, 15 skipped**, no failures.
+
+## Follow-ups
+
+- None required for this PR. The descent iteration cap is currently only a
+  warning; if a future review wants it to raise, the `else:` branches are
+  the single place to change.

--- a/src/instruments/asmi/driver.py
+++ b/src/instruments/asmi/driver.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import statistics
 import time
 from typing import Optional
@@ -19,13 +20,16 @@ _STEP_COUNT_SAFETY_MARGIN = 10
 def _step_count_bound(z_upper: float, z_lower: float, step_size: float) -> int:
     """Upper bound on steps needed to cross [z_lower, z_upper] at step_size.
 
-    Used as a loop-iteration cap to guarantee termination if hardware stalls
-    or rounding otherwise prevents the geometric exit condition from firing.
+    Ceil-based so that a non-integer number of steps still reaches the
+    clamped endpoint. Used as a loop-iteration cap to guarantee termination
+    if hardware stalls or rounding otherwise prevents the geometric exit
+    condition from firing, and — in offline mode — as the actual step count.
     """
     if step_size <= 0:
         raise ValueError(f"step_size must be positive, got {step_size}")
     span = abs(z_upper - z_lower)
-    return int(span / step_size) + _STEP_COUNT_SAFETY_MARGIN
+    raw_steps = math.ceil(span / step_size) if span > 0 else 0
+    return raw_steps + _STEP_COUNT_SAFETY_MARGIN
 
 
 class ASMI(BaseInstrument):

--- a/src/instruments/asmi/driver.py
+++ b/src/instruments/asmi/driver.py
@@ -13,6 +13,19 @@ from instruments.asmi.models import ASMIStatus, MeasurementResult
 
 _DEFAULT_FORCE_THRESHOLD = -100
 _DEFAULT_SENSOR_CHANNELS = [1]
+_STEP_COUNT_SAFETY_MARGIN = 10
+
+
+def _step_count_bound(z_upper: float, z_lower: float, step_size: float) -> int:
+    """Upper bound on steps needed to cross [z_lower, z_upper] at step_size.
+
+    Used as a loop-iteration cap to guarantee termination if hardware stalls
+    or rounding otherwise prevents the geometric exit condition from firing.
+    """
+    if step_size <= 0:
+        raise ValueError(f"step_size must be positive, got {step_size}")
+    span = abs(z_upper - z_lower)
+    return int(span / step_size) + _STEP_COUNT_SAFETY_MARGIN
 
 
 class ASMI(BaseInstrument):
@@ -221,6 +234,7 @@ class ASMI(BaseInstrument):
         force_limit: float | None = None,
         measurement_height: float | None = None,
         baseline_samples: int | None = None,
+        measure_with_return: bool = False,
     ) -> dict:
         """Perform step-by-step indentation at the current XY position.
 
@@ -238,10 +252,16 @@ class ASMI(BaseInstrument):
             force_limit:        Stop when corrected force exceeds this in N (overrides instance default).
             measurement_height: Z to descend to before starting (overrides instance default).
             baseline_samples:   Number of baseline force readings (overrides instance default).
+            measure_with_return:
+                                If True, after descent also step Z back up to
+                                ``measurement_height`` and record each upward sample.
+                                Every sample is tagged with ``direction`` ("down"
+                                on descent, "up" on return).
 
         Returns:
             Dict with keys: measurements, baseline_avg, baseline_std,
-            force_exceeded, data_points.
+            force_exceeded, data_points, measure_with_return. Every entry in
+            ``measurements`` includes a ``direction`` field.
         """
         # Allow protocol method_kwargs to override instance defaults
         _z_target = z_limit if z_limit is not None else self._z_target
@@ -253,7 +273,13 @@ class ASMI(BaseInstrument):
         _baseline_samples = baseline_samples if baseline_samples is not None else self._baseline_samples
 
         if self._offline:
-            return self._offline_indentation(gantry, _z_target, _step_size, _well_top_z)
+            return self._offline_indentation(
+                gantry,
+                _z_target,
+                _step_size,
+                _well_top_z,
+                measure_with_return=measure_with_return,
+            )
 
         coords = gantry.get_coordinates()
         cur_x, cur_y = coords["x"], coords["y"]
@@ -269,8 +295,9 @@ class ASMI(BaseInstrument):
 
         measurements = []
         force_exceeded = False
+        max_steps = _step_count_bound(_well_top_z, _z_target, _step_size)
 
-        while True:
+        for _ in range(max_steps):
             coords = gantry.get_coordinates()
             current_z = coords["z"]
             if current_z <= _z_target:
@@ -287,6 +314,7 @@ class ASMI(BaseInstrument):
                 "z_mm": coords["z"],
                 "raw_force_n": force,
                 "corrected_force_n": corrected,
+                "direction": "down",
             })
 
             if len(measurements) % 10 == 0:
@@ -302,6 +330,48 @@ class ASMI(BaseInstrument):
                 )
                 force_exceeded = True
                 break
+        else:
+            self.logger.warning(
+                "Descent hit iteration cap %d before reaching z_target %.3f",
+                max_steps, _z_target,
+            )
+
+        if measure_with_return and measurements:
+            self.logger.info(
+                "Starting return sweep (%d descent samples collected)",
+                len(measurements),
+            )
+            return_cap = _step_count_bound(_well_top_z, _z_target, _step_size)
+            for _ in range(return_cap):
+                coords = gantry.get_coordinates()
+                current_z = coords["z"]
+                if current_z >= _well_top_z:
+                    break
+                next_z = min(current_z + _step_size, _well_top_z)
+                self._move_z(gantry, cur_x, cur_y, next_z)
+                coords = gantry.get_coordinates()
+                # Break if the gantry did not advance — prevents infinite loop
+                # on stalled axis. get_coordinates reflects the real position.
+                if coords["z"] <= current_z:
+                    self.logger.warning(
+                        "Return sweep aborted: gantry Z did not advance (%.3f)",
+                        current_z,
+                    )
+                    break
+                force = self.get_force_reading()
+                corrected = force - baseline_avg
+                measurements.append({
+                    "timestamp": time.time(),
+                    "z_mm": coords["z"],
+                    "raw_force_n": force,
+                    "corrected_force_n": corrected,
+                    "direction": "up",
+                })
+            else:
+                self.logger.warning(
+                    "Return sweep hit iteration cap %d before reaching well_top_z %.3f",
+                    return_cap, _well_top_z,
+                )
 
         return {
             "measurements": measurements,
@@ -309,25 +379,53 @@ class ASMI(BaseInstrument):
             "baseline_std": baseline_std,
             "force_exceeded": force_exceeded,
             "data_points": len(measurements),
+            "measure_with_return": measure_with_return,
         }
 
-    def _offline_indentation(self, gantry, z_limit, step_size, measurement_height) -> dict:
+    def _offline_indentation(
+        self,
+        gantry,
+        z_limit,
+        step_size,
+        measurement_height,
+        measure_with_return: bool = False,
+    ) -> dict:
         """Fast offline indentation — no idle-wait, synthetic data."""
         coords = gantry.get_coordinates()
         cur_x, cur_y = coords["x"], coords["y"]
         gantry.move_to(cur_x, cur_y, measurement_height)
 
+        # Integer step counting avoids float accumulation drift at loop boundaries.
+        n_down = _step_count_bound(measurement_height, z_limit, step_size) - _STEP_COUNT_SAFETY_MARGIN
         measurements = []
-        z = measurement_height
-        while z > z_limit:
-            z -= step_size
+        for i in range(1, n_down + 1):
+            z = max(measurement_height - i * step_size, z_limit)
             gantry.move_to(cur_x, cur_y, z)
             measurements.append({
                 "timestamp": time.time(),
                 "z_mm": z,
                 "raw_force_n": self._default_force,
                 "corrected_force_n": 0.0,
+                "direction": "down",
             })
+            if z <= z_limit:
+                break
+
+        if measure_with_return:
+            z_bottom = measurements[-1]["z_mm"] if measurements else measurement_height
+            n_up = _step_count_bound(measurement_height, z_bottom, step_size) - _STEP_COUNT_SAFETY_MARGIN
+            for i in range(1, n_up + 1):
+                z = min(z_bottom + i * step_size, measurement_height)
+                gantry.move_to(cur_x, cur_y, z)
+                measurements.append({
+                    "timestamp": time.time(),
+                    "z_mm": z,
+                    "raw_force_n": self._default_force,
+                    "corrected_force_n": 0.0,
+                    "direction": "up",
+                })
+                if z >= measurement_height:
+                    break
 
         return {
             "measurements": measurements,
@@ -335,4 +433,5 @@ class ASMI(BaseInstrument):
             "baseline_std": 0.0,
             "force_exceeded": False,
             "data_points": len(measurements),
+            "measure_with_return": measure_with_return,
         }

--- a/src/protocol_engine/measurements.py
+++ b/src/protocol_engine/measurements.py
@@ -131,18 +131,32 @@ def normalize_measurement(
 
     if isinstance(raw_result, dict) and "measurements" in raw_result:
         steps = raw_result["measurements"]
+        has_direction = any("direction" in s for s in steps)
+        payload = {
+            "z_positions_mm": [s["z_mm"] for s in steps],
+            "raw_forces_n": [s["raw_force_n"] for s in steps],
+            "corrected_forces_n": [s["corrected_force_n"] for s in steps],
+        }
+        if has_direction:
+            # Default missing entries to "down" (legacy pre-dual-sweep payloads)
+            # but warn so callers can detect mid-run corruption where only
+            # part of a return sweep was tagged.
+            if not all("direction" in s for s in steps):
+                import logging
+                logging.getLogger(__name__).warning(
+                    "Partial 'direction' tags in ASMI indentation steps; "
+                    "defaulting missing entries to 'down'",
+                )
+            payload["directions"] = [s.get("direction", "down") for s in steps]
         return InstrumentMeasurement(
             measurement_type=MeasurementType.ASMI_INDENTATION,
-            payload={
-                "z_positions_mm": [s["z_mm"] for s in steps],
-                "raw_forces_n": [s["raw_force_n"] for s in steps],
-                "corrected_forces_n": [s["corrected_force_n"] for s in steps],
-            },
+            payload=payload,
             metadata={
                 "baseline_avg": raw_result.get("baseline_avg", 0.0),
                 "baseline_std": raw_result.get("baseline_std", 0.0),
                 "force_exceeded": raw_result.get("force_exceeded", False),
                 "data_points": raw_result.get("data_points", len(steps)),
+                "measure_with_return": raw_result.get("measure_with_return", False),
                 "instrument_name": instrument_name,
                 "method_name": method_name,
             },

--- a/src/protocol_engine/measurements.py
+++ b/src/protocol_engine/measurements.py
@@ -131,23 +131,24 @@ def normalize_measurement(
 
     if isinstance(raw_result, dict) and "measurements" in raw_result:
         steps = raw_result["measurements"]
-        has_direction = any("direction" in s for s in steps)
+        # Warn when direction tags are partial — mid-run corruption signal.
+        # Current ASMI driver always tags; missing entries default to "down"
+        # for legacy/partial payloads, and directions is always emitted so
+        # downstream consumers see a stable schema.
+        has_any_direction = any("direction" in s for s in steps)
+        has_all_directions = all("direction" in s for s in steps) if steps else True
+        if has_any_direction and not has_all_directions:
+            import logging
+            logging.getLogger(__name__).warning(
+                "Partial 'direction' tags in ASMI indentation steps; "
+                "defaulting missing entries to 'down'",
+            )
         payload = {
             "z_positions_mm": [s["z_mm"] for s in steps],
             "raw_forces_n": [s["raw_force_n"] for s in steps],
             "corrected_forces_n": [s["corrected_force_n"] for s in steps],
+            "directions": [s.get("direction", "down") for s in steps],
         }
-        if has_direction:
-            # Default missing entries to "down" (legacy pre-dual-sweep payloads)
-            # but warn so callers can detect mid-run corruption where only
-            # part of a return sweep was tagged.
-            if not all("direction" in s for s in steps):
-                import logging
-                logging.getLogger(__name__).warning(
-                    "Partial 'direction' tags in ASMI indentation steps; "
-                    "defaulting missing entries to 'down'",
-                )
-            payload["directions"] = [s.get("direction", "down") for s in steps]
         return InstrumentMeasurement(
             measurement_type=MeasurementType.ASMI_INDENTATION,
             payload=payload,

--- a/tests/instruments/test_asmi.py
+++ b/tests/instruments/test_asmi.py
@@ -123,11 +123,12 @@ class TestASMIOffline(unittest.TestCase):
         self.assertAlmostEqual(up_z[-1], -10.0, places=6)
 
     def test_indentation_offline_return_no_float_drift(self):
-        """Return loop must terminate even when step_size doesn't divide the range evenly."""
+        """Descent must reach z_limit and return must hit measurement_height exactly,
+        even when step_size doesn't divide the range evenly."""
         from gantry.gantry import Gantry
         gantry = Gantry(offline=True)
 
-        # 0.03 does not evenly divide 2.0 (66.66 steps).
+        # 0.03 does not evenly divide 2.0 (66.67 steps → ceil to 67).
         result = self.asmi.indentation(
             gantry,
             z_limit=-12.0,
@@ -136,8 +137,30 @@ class TestASMIOffline(unittest.TestCase):
             measure_with_return=True,
         )
 
+        down_z = [s["z_mm"] for s in result["measurements"] if s["direction"] == "down"]
         up_z = [s["z_mm"] for s in result["measurements"] if s["direction"] == "up"]
+        self.assertAlmostEqual(down_z[-1], -12.0, places=6)
         self.assertAlmostEqual(up_z[-1], -10.0, places=6)
+
+    def test_indentation_offline_step_larger_than_span_takes_one_step(self):
+        """When step_size exceeds the span, one clamped step must still occur."""
+        from gantry.gantry import Gantry
+        gantry = Gantry(offline=True)
+
+        result = self.asmi.indentation(
+            gantry,
+            z_limit=-10.05,
+            measurement_height=-10.0,
+            step_size=0.5,
+            measure_with_return=True,
+        )
+
+        down_z = [s["z_mm"] for s in result["measurements"] if s["direction"] == "down"]
+        up_z = [s["z_mm"] for s in result["measurements"] if s["direction"] == "up"]
+        self.assertEqual(len(down_z), 1)
+        self.assertAlmostEqual(down_z[0], -10.05, places=6)
+        self.assertEqual(len(up_z), 1)
+        self.assertAlmostEqual(up_z[0], -10.0, places=6)
 
 
 class _FakeOnlineGantry:

--- a/tests/instruments/test_asmi.py
+++ b/tests/instruments/test_asmi.py
@@ -1,6 +1,7 @@
 """Tests for the ASMI instrument driver (offline mode)."""
 
 import unittest
+from unittest.mock import patch
 
 from instruments.asmi.driver import ASMI
 from instruments.asmi.models import ASMIStatus, MeasurementResult
@@ -47,13 +48,10 @@ class TestASMIOffline(unittest.TestCase):
         """Offline indentation should return synthetic measurements quickly."""
         from gantry.gantry import Gantry
         gantry = Gantry(offline=True)
-        # Use small range for fast test
-        self.asmi._z_target = -12.0
-        self.asmi._well_top_z = -10.0
-        self.asmi._step_size = 0.1
-        self.asmi._safe_z = -5.0
 
-        result = self.asmi.indentation(gantry)
+        result = self.asmi.indentation(
+            gantry, z_limit=-12.0, measurement_height=-10.0, step_size=0.1,
+        )
 
         self.assertIn("measurements", result)
         self.assertIn("baseline_avg", result)
@@ -61,6 +59,171 @@ class TestASMIOffline(unittest.TestCase):
         self.assertEqual(result["data_points"], len(result["measurements"]))
         self.assertGreater(result["data_points"], 0)
         self.assertFalse(result["force_exceeded"])
+        self.assertFalse(result["measure_with_return"])
+
+    def test_indentation_offline_with_return_includes_directions(self):
+        """Return-mode indentation should include both down and up direction samples."""
+        from gantry.gantry import Gantry
+        gantry = Gantry(offline=True)
+
+        result = self.asmi.indentation(
+            gantry,
+            z_limit=-12.0,
+            measurement_height=-10.0,
+            step_size=0.1,
+            measure_with_return=True,
+        )
+
+        self.assertTrue(result["measure_with_return"])
+        directions = [step.get("direction") for step in result["measurements"]]
+        self.assertIn("down", directions)
+        self.assertIn("up", directions)
+
+    def test_indentation_offline_emits_direction_unconditionally(self):
+        """Every sample should carry a direction tag, even without return mode."""
+        from gantry.gantry import Gantry
+        gantry = Gantry(offline=True)
+
+        result = self.asmi.indentation(
+            gantry, z_limit=-12.0, measurement_height=-10.0, step_size=0.1,
+        )
+
+        self.assertGreater(len(result["measurements"]), 0)
+        for step in result["measurements"]:
+            self.assertEqual(step["direction"], "down")
+
+    def test_indentation_offline_return_preserves_ordering_and_monotonicity(self):
+        """All down samples must precede all up samples; z descends then ascends."""
+        from gantry.gantry import Gantry
+        gantry = Gantry(offline=True)
+
+        result = self.asmi.indentation(
+            gantry,
+            z_limit=-12.0,
+            measurement_height=-10.0,
+            step_size=0.1,
+            measure_with_return=True,
+        )
+
+        steps = result["measurements"]
+        directions = [s["direction"] for s in steps]
+        last_down = max(i for i, d in enumerate(directions) if d == "down")
+        first_up = min(i for i, d in enumerate(directions) if d == "up")
+        self.assertLess(last_down, first_up)
+
+        down_z = [s["z_mm"] for s in steps if s["direction"] == "down"]
+        up_z = [s["z_mm"] for s in steps if s["direction"] == "up"]
+        # Down: each z strictly lower than the previous (gantry goes more negative).
+        for prev, curr in zip(down_z, down_z[1:]):
+            self.assertLess(curr, prev)
+        # Up: each z strictly higher than the previous.
+        for prev, curr in zip(up_z, up_z[1:]):
+            self.assertGreater(curr, prev)
+        # Return terminates at measurement_height (well top), never overshoots.
+        self.assertAlmostEqual(up_z[-1], -10.0, places=6)
+
+    def test_indentation_offline_return_no_float_drift(self):
+        """Return loop must terminate even when step_size doesn't divide the range evenly."""
+        from gantry.gantry import Gantry
+        gantry = Gantry(offline=True)
+
+        # 0.03 does not evenly divide 2.0 (66.66 steps).
+        result = self.asmi.indentation(
+            gantry,
+            z_limit=-12.0,
+            measurement_height=-10.0,
+            step_size=0.03,
+            measure_with_return=True,
+        )
+
+        up_z = [s["z_mm"] for s in result["measurements"] if s["direction"] == "up"]
+        self.assertAlmostEqual(up_z[-1], -10.0, places=6)
+
+
+class _FakeOnlineGantry:
+    """Minimal gantry stub for exercising ASMI online indentation loops."""
+
+    def __init__(self, start_z: float):
+        self._z = start_z
+
+    def get_coordinates(self) -> dict:
+        return {"x": 0.0, "y": 0.0, "z": self._z}
+
+    def get_status(self) -> str:
+        return "Idle"
+
+    def move_to(self, x: float, y: float, z: float) -> None:
+        self._z = z
+
+
+class TestASMIOnlineIndentation(unittest.TestCase):
+    """Exercise the non-offline indentation code path with mocked hardware I/O."""
+
+    def _make_online_asmi(self) -> ASMI:
+        asmi = ASMI(offline=False, default_force=0.0)
+        asmi._offline = False
+        return asmi
+
+    def test_online_indentation_with_return_records_both_directions(self):
+        asmi = self._make_online_asmi()
+        gantry = _FakeOnlineGantry(start_z=-10.0)
+
+        with patch.object(asmi, "get_baseline_force", return_value=(0.0, 0.0)), \
+             patch.object(asmi, "get_force_reading", return_value=0.1):
+            result = asmi.indentation(
+                gantry,
+                z_limit=-10.5,
+                measurement_height=-10.0,
+                step_size=0.1,
+                force_limit=100.0,
+                baseline_samples=1,
+                measure_with_return=True,
+            )
+
+        directions = [s["direction"] for s in result["measurements"]]
+        self.assertIn("down", directions)
+        self.assertIn("up", directions)
+        up_z = [s["z_mm"] for s in result["measurements"] if s["direction"] == "up"]
+        self.assertAlmostEqual(up_z[-1], -10.0, places=6)
+
+    def test_online_return_terminates_even_if_gantry_stalls(self):
+        """If gantry Z never advances, return loop must bail via iteration cap, not spin."""
+        asmi = self._make_online_asmi()
+
+        class StalledGantry(_FakeOnlineGantry):
+            def move_to(self, x, y, z):
+                # Simulate a stalled axis: position never changes.
+                pass
+
+        gantry = StalledGantry(start_z=-10.0)
+        # Prime descent by letting z reach z_limit on the first real move; we
+        # only need _some_ descent measurement to trigger the return block.
+        original_move = _FakeOnlineGantry.move_to
+        call_count = {"n": 0}
+
+        def move_once_then_stall(self, x, y, z):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                original_move(self, x, y, z)  # initial descend to measurement_height
+            elif call_count["n"] == 2:
+                original_move(self, x, y, z)  # one descent step
+            # subsequent moves no-op → stall during return
+
+        with patch.object(StalledGantry, "move_to", move_once_then_stall), \
+             patch.object(asmi, "get_baseline_force", return_value=(0.0, 0.0)), \
+             patch.object(asmi, "get_force_reading", return_value=0.0):
+            result = asmi.indentation(
+                gantry,
+                z_limit=-10.1,
+                measurement_height=-10.0,
+                step_size=0.1,
+                force_limit=100.0,
+                baseline_samples=1,
+                measure_with_return=True,
+            )
+
+        # The test's real requirement: the call returns, i.e. no infinite loop.
+        self.assertIn("measurements", result)
 
 
 class TestASMIOnlineRequiresHardware(unittest.TestCase):

--- a/tests/protocol_engine/test_measurements.py
+++ b/tests/protocol_engine/test_measurements.py
@@ -58,3 +58,73 @@ class TestNormalizeMeasurement:
                 method_name="measure",
                 raw_result=object(),
             )
+
+    def test_normalize_asmi_indentation_without_return_mode(self):
+        raw_result = {
+            "measurements": [
+                {"z_mm": -73.01, "raw_force_n": 0.10, "corrected_force_n": 0.01},
+                {"z_mm": -73.02, "raw_force_n": 0.11, "corrected_force_n": 0.02},
+            ],
+            "baseline_avg": 0.09,
+            "baseline_std": 0.001,
+            "force_exceeded": False,
+            "data_points": 2,
+        }
+
+        measurement = normalize_measurement(
+            instrument_name="asmi",
+            method_name="indentation",
+            raw_result=raw_result,
+        )
+
+        assert measurement.measurement_type == MeasurementType.ASMI_INDENTATION
+        assert measurement.payload["z_positions_mm"] == [-73.01, -73.02]
+        assert "directions" not in measurement.payload
+        assert measurement.metadata["measure_with_return"] is False
+
+    def test_normalize_asmi_indentation_with_return_mode(self):
+        raw_result = {
+            "measurements": [
+                {"z_mm": -73.01, "raw_force_n": 0.10, "corrected_force_n": 0.01, "direction": "down"},
+                {"z_mm": -73.02, "raw_force_n": 0.11, "corrected_force_n": 0.02, "direction": "down"},
+                {"z_mm": -73.01, "raw_force_n": 0.09, "corrected_force_n": 0.00, "direction": "up"},
+            ],
+            "baseline_avg": 0.09,
+            "baseline_std": 0.001,
+            "force_exceeded": False,
+            "data_points": 3,
+            "measure_with_return": True,
+        }
+
+        measurement = normalize_measurement(
+            instrument_name="asmi",
+            method_name="indentation",
+            raw_result=raw_result,
+        )
+
+        assert measurement.measurement_type == MeasurementType.ASMI_INDENTATION
+        assert measurement.payload["directions"] == ["down", "down", "up"]
+        assert measurement.metadata["measure_with_return"] is True
+
+    def test_normalize_asmi_partial_direction_defaults_missing_to_down(self):
+        """Mixed-tag step lists (one sample missing ``direction``) must default missing entries to 'down'."""
+        raw_result = {
+            "measurements": [
+                {"z_mm": -73.01, "raw_force_n": 0.10, "corrected_force_n": 0.01, "direction": "down"},
+                {"z_mm": -73.02, "raw_force_n": 0.11, "corrected_force_n": 0.02},
+                {"z_mm": -73.01, "raw_force_n": 0.09, "corrected_force_n": 0.00, "direction": "up"},
+            ],
+            "baseline_avg": 0.09,
+            "baseline_std": 0.001,
+            "force_exceeded": False,
+            "data_points": 3,
+            "measure_with_return": True,
+        }
+
+        measurement = normalize_measurement(
+            instrument_name="asmi",
+            method_name="indentation",
+            raw_result=raw_result,
+        )
+
+        assert measurement.payload["directions"] == ["down", "down", "up"]

--- a/tests/protocol_engine/test_measurements.py
+++ b/tests/protocol_engine/test_measurements.py
@@ -79,7 +79,9 @@ class TestNormalizeMeasurement:
 
         assert measurement.measurement_type == MeasurementType.ASMI_INDENTATION
         assert measurement.payload["z_positions_mm"] == [-73.01, -73.02]
-        assert "directions" not in measurement.payload
+        # Legacy untagged payloads default to "down" so the normalized
+        # schema always exposes directions.
+        assert measurement.payload["directions"] == ["down", "down"]
         assert measurement.metadata["measure_with_return"] is False
 
     def test_normalize_asmi_indentation_with_return_mode(self):


### PR DESCRIPTION
## Summary
- Adds `measure_with_return` flag to `ASMI.indentation` so the instrument records upward samples back to `measurement_height` after descent, tagging every sample with `direction` ("down" / "up"). Aligns CubOS with the dual-indentation functionality on the asmi-new main branch.
- Hardens the descent and return loops with an explicit iteration cap plus a stall-detection guard (break when gantry Z does not advance), fixing the infinite-loop risk flagged during PR review.
- Rewrites the offline descent/return paths with integer-indexed iteration to eliminate float drift; the return sweep now terminates exactly at `measurement_height` regardless of whether `step_size` divides the range evenly.
- Makes `direction` unconditional on every sample for a stable downstream schema, and warns in `normalize_measurement` when only some samples carry a direction tag (mid-run corruption signal).

## Test plan
- [x] `pytest tests/instruments/test_asmi.py tests/protocol_engine/test_measurements.py --timeout=10` — 24 passed
- [x] `pytest --timeout=30` full suite — 875 passed, 15 skipped
- [x] New tests cover: unconditional direction, descent→return ordering and z-monotonicity, float-drift termination, online-path happy case, online-path stall termination, normalizer mixed-tag handling
- [ ] Manual run against real hardware — pending user verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)