### PR TITLE
Move Z-travel safety from mill to protocol layer

### DIFF
--- a/configs/protocol/asmi_indentation.yaml
+++ b/configs/protocol/asmi_indentation.yaml
@@ -29,6 +29,7 @@ protocol:
         force_limit: 10.0
         measurement_height: -73.0
         baseline_samples: 10
+        measure_with_return: false
 
   # Return to safe Z after scan
   - move:

--- a/docs/board.md
+++ b/docs/board.md
@@ -84,7 +84,7 @@ Vernier GoDirect force sensor for indentation measurements.
 | Method | Description |
 |--------|-------------|
 | `measure(n_samples)` | Take force readings. |
-| `indentation(gantry, z_limit, step_size, force_limit, measurement_height, baseline_samples)` | Step-by-step indentation: descend in Z steps, reading force at each step until force limit or Z limit. |
+| `indentation(gantry, z_limit, step_size, force_limit, measurement_height, baseline_samples, measure_with_return=False)` | Step-by-step indentation: descend in Z steps, reading force at each step until force limit or Z limit. Pass `measure_with_return=True` to also record upward return samples; every measurement carries a `direction` tag (`"down"` or `"up"`). |
 | `get_force_reading()` | Single instantaneous force reading. |
 | `get_baseline_force(samples)` | Average force over N samples (returns mean and std). |
 | `get_status()` | Return sensor state. |

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -33,6 +33,7 @@ protocol:
         force_limit: 10.0
         measurement_height: -73.0
         baseline_samples: 10
+        measure_with_return: false  # true = down + return (up) sampling
 
   # Return to safe Z after scan
   - move:

--- a/progress/2026-04-15.md
+++ b/progress/2026-04-15.md
@@ -1,0 +1,106 @@
+# 2026-04-15 — ASMI dual indentation PR review fixes
+
+## Context
+
+Branch: `feat/asmi-dual-indentation-protocol`. This feature adds a
+`measure_with_return` flag to `ASMI.indentation` so that after descending to
+`z_limit`, the instrument also records upward samples back to
+`measurement_height`, tagging each sample with `direction="down"` or `"up"`.
+Goal is to align CubOS with the dual-indentation functionality on the
+asmi-new main branch.
+
+Ran `/pr-review-toolkit:review-pr` first. Four agents (code-reviewer,
+pr-test-analyzer, silent-failure-hunter, comment-analyzer) flagged a mix of
+critical loop-safety issues, schema inconsistencies, and test gaps.
+
+## Work done
+
+All fixes below implemented against the unstaged working-tree changes.
+
+### Driver (`src/instruments/asmi/driver.py`)
+
+- Added `_step_count_bound(z_upper, z_lower, step_size)` helper at module
+  scope. Returns an upper bound on the number of steps required to cross a
+  Z span, with a safety margin. Raises `ValueError` if `step_size <= 0`.
+- Replaced the online descent `while True` with a `for _ in range(max_steps)`
+  bounded by `_step_count_bound`. Added `else:` clause logging a warning if
+  the cap is hit before reaching `z_target`.
+- Replaced the online return `while True` with the same bounded loop. Added
+  an in-loop guard: if `gantry.get_coordinates()` shows Z did not advance
+  after a `move_to`, log a warning and break (stall detection). This is
+  what prevented the original code from terminating when the gantry refused
+  to move.
+- Made `direction` unconditional on every sample in both online and offline
+  paths. Previously it was only emitted when `measure_with_return=True`,
+  producing heterogeneous dicts.
+- Added an info log when the return sweep starts (observability request
+  from review).
+- Rewrote offline descent/return as integer-indexed `for` loops (`range(1,
+  n+1)` with `max(..., z_limit)` / `min(..., measurement_height)` clamps).
+  Eliminates the float-accumulation drift the review flagged.
+- Tightened the `indentation` docstring to describe the return target,
+  every sample being tagged, and the full return-value schema.
+
+Per the user's guidance ("return force is less than downward force") we did
+**not** add a force-limit check to the return stroke. Descent force check
+is unchanged.
+
+### Normalizer (`src/protocol_engine/measurements.py`)
+
+- Added a warning log when `direction` tags are present on only *some*
+  steps. This catches mid-run corruption where part of a return sweep was
+  lost. Legacy fully-untagged payloads remain silent; the default to
+  `"down"` for missing entries is preserved.
+
+### Tests
+
+- `tests/instruments/test_asmi.py`:
+  - Migrated the existing indentation tests to pass overrides via kwargs
+    (`z_limit=`, `measurement_height=`, `step_size=`) instead of mutating
+    private attributes.
+  - `test_indentation_offline_emits_direction_unconditionally`: every
+    sample carries `direction="down"` even without return mode.
+  - `test_indentation_offline_return_preserves_ordering_and_monotonicity`:
+    all `down` samples precede all `up` samples; descent Z is strictly
+    decreasing, return Z strictly increasing, return terminates exactly at
+    `measurement_height`.
+  - `test_indentation_offline_return_no_float_drift`: step_size that does
+    not evenly divide the range still terminates cleanly at
+    `measurement_height`.
+  - New `TestASMIOnlineIndentation` class covers the `_offline=False` path
+    for the first time, using a minimal `_FakeOnlineGantry` stub plus
+    `mock.patch.object` on `get_force_reading` / `get_baseline_force`.
+    Two tests: happy path with both directions recorded, and a
+    stall-simulating gantry that would previously have spun forever.
+- `tests/protocol_engine/test_measurements.py`:
+  - `test_normalize_asmi_partial_direction_defaults_missing_to_down`:
+    mixed-tag step lists coerce missing entries to `"down"`.
+
+### Docs
+
+- `docs/board.md`: changed `measure_with_return=true` (YAML-style) to
+  `True` in the Python-signature table entry and expanded the description
+  to note that every measurement carries a `direction` tag.
+- `docs/protocol.md`: unchanged — the YAML example already uses lowercase
+  `false` correctly.
+
+## Issues found and how resolved
+
+- **Stall test hung on first run.** Confirms the infinite-loop bug the
+  review flagged. Added `pytest-timeout` (`--timeout=10`) to the test
+  environment to catch future regressions fast, and the fix (iteration cap
+  plus stall-break in the return loop) resolves it cleanly.
+- **Python 3.9 venv checked in at `venv/` cannot run the codebase** (pipe
+  syntax `float | None` requires 3.10+). Built a fresh 3.11 venv at
+  `/tmp/cubos-venv-311` for test execution only; no repo changes.
+
+## Test results
+
+- `pytest tests/instruments/test_asmi.py tests/protocol_engine/test_measurements.py --timeout=10` →  24 passed.
+- Full suite `pytest --timeout=30` → **875 passed, 15 skipped**, no failures.
+
+## Follow-ups
+
+- None required for this PR. The descent iteration cap is currently only a
+  warning; if a future review wants it to raise, the `else:` branches are
+  the single place to change.

--- a/progress/2026-04-15.md
+++ b/progress/2026-04-15.md
@@ -104,3 +104,100 @@ is unchanged.
 - None required for this PR. The descent iteration cap is currently only a
   warning; if a future review wants it to raise, the `else:` branches are
   the single place to change.
+
+---
+
+# 2026-04-15 — Fix scan's max-Z detour; lift safety from mill to protocol layer
+
+## Context
+
+Branch: `fix/scan-max-z-detour`. A UV-Vis CCS scan over a well plate
+produced a Z sequence of `measure_z → safe_approach_z → max_z → XY at
+max_z → safe_approach_z → measure_z` between every well pair. The
+full-height retract to `max_z_height` on every XY travel was slow and
+pointless once `Board.move_to_labware` had already established a safe
+travel height via `safe_approach_height`.
+
+Root cause: `Mill.safe_move` unconditionally prepended `G01
+Z{max_z_height}` to any XY-changing move from below `max_z_height`.
+That safety lived at the lowest layer of the stack — the mill driver —
+which is the wrong place for it. The protocol layer already expresses
+"how high to travel above THIS labware" via per-instrument
+`safe_approach_height`.
+
+## Work done
+
+### CubOS (`fix/scan-max-z-detour`)
+
+**Mill (`src/gantry/gantry_driver/driver.py`)**
+
+- Deleted `Mill.safe_move`, `__should_move_to_safe_position_first`,
+  `move_to_positions` (plural; zero callers), `move_to_safe_position`
+  (zero callers), `check_max_z_height`, and the `max_z_height` attr.
+  The mill no longer makes safety decisions about Z travel.
+- Rewrote `Mill.move_to_position(..., travel_z=None)` as the single
+  load-bearing move primitive. With `travel_z=None` it's a direct
+  move (component-wise below `safe_z_height`, diagonal above). With
+  `travel_z` given, it issues lift → XY → descend, skipping each step
+  when it would produce no motion.
+- Removed the `move_z_first` param from
+  `_generate_movement_commands`; its only caller (`safe_move`) is
+  gone. Added `_generate_transit_commands(current, target, travel_z)`.
+- `homing_sequence` no longer calls `check_max_z_height`.
+
+**Gantry (`src/gantry/gantry.py`)**
+
+- `Gantry.move_to(x, y, z, travel_z=None)` now delegates to
+  `Mill.move_to_position`, translating `travel_z` from user space to
+  machine space alongside the target.
+- Deleted `Gantry.set_safe_z` (configured `max_z_height`; zero
+  remaining consumers).
+
+**Board (`src/board/board.py`)**
+
+- `Board.move(..., travel_z=None)` forwards an instrument-tip-frame
+  `travel_z` through to `Gantry.move_to`, subtracting instrument
+  `depth` like the target z does.
+- `Board.move_to_labware` is now one `move` call:
+  `self.move(instr, (x, y, approach_z), travel_z=approach_z)`. The
+  mill emits the retract-travel-descend sequence from that single
+  command. Dropped `_current_tip_position`, `_Z_TOLERANCE_MM`, and
+  the two-call retract-if-below branch — all subsumed by `travel_z`
+  semantics.
+
+**Tests**
+
+- Rewrote `TestBoardMoveToLabware` around the one-call contract.
+- Retargeted gantry tests from `safe_move` to `move_to_position`,
+  added `travel_z` translation assertions.
+- Added two `_generate_transit_commands` tests covering the
+  scan-transition G-code order and the "already at travel_z" skip.
+- Renamed the wpos-enforcement test to
+  `test_move_to_position_uses_wpos_internally`.
+
+### SHARC (`fix/remove-set-safe-z`)
+
+- `main_uv.py`: removed the `safe_z = …z_max` lookup and
+  `gantry.set_safe_z(safe_z)` call. `set_safe_z` is gone in CubOS.
+- `config/board.yaml`: added `safe_approach_height: 0.0` to
+  `uv_system` (and the commented `uvvis_ccs`). With SHARC's
+  `labware.z = 0.0`, that puts XY travel at Z = 0 — the same
+  top-of-volume height the old `set_safe_z(z_max=0.0)` enforced via
+  the mill-level retract.
+
+## Test results
+
+- `pytest` (cubos): **871 passed, 15 skipped, 1 failed**. The failure
+  is the pre-existing
+  `test_distribution_artifacts_include_registry_yaml` `bdist_wheel`
+  issue documented on the labware branch — unrelated.
+
+## Architectural note
+
+`safe_approach_height` and `max_z_height` addressed the same concern
+from two different layers. Keeping both was redundant and forced the
+surplus max-Z detour. By deleting the mill-level retract and making
+`travel_z` a parameter on the move primitive, the protocol layer now
+owns the full safety model: "travel at approach_z above THIS labware"
+is expressed once, at the instrument config, and carried through to
+the G-code.

--- a/src/board/board.py
+++ b/src/board/board.py
@@ -13,12 +13,6 @@ if TYPE_CHECKING:
 # (e.g. a labware object sitting at a fixed deck location).
 Position = Any
 
-# Tolerance for Z-offset comparisons in Board.move_to_labware. The gantry's
-# physical encoder resolution is ~1e-4 mm (0.1 μm), so sub-0.1 μm differences
-# are dominated by numerical noise, not real motion. A tighter tolerance
-# (e.g. 1e-9) would fire spurious retract/lower moves on floating-point drift.
-_Z_TOLERANCE_MM = 1e-4
-
 
 class Board:
     """Physical board layout: a gantry and the instruments mounted on it.
@@ -42,6 +36,7 @@ class Board:
         self,
         instrument: str | BaseInstrument,
         position: Position,
+        travel_z: float | None = None,
     ) -> None:
         """Move the gantry so that *instrument* arrives at *position*.
 
@@ -50,9 +45,16 @@ class Board:
         at the requested (x, y, z). Validates that the target is finite
         (no NaN/Inf) before commanding the gantry.
 
+        ``travel_z``, if given, is an instrument-tip Z held during XY
+        travel — the gantry lifts/lowers to it before moving XY, then
+        descends/ascends to the target Z. ``Board.move_to_labware`` uses
+        this to travel at ``safe_approach_height`` between labware.
+
         Args:
             instrument: Name (key in ``self.instruments``) or instance.
             position:   (x, y, z) tuple or labware object with x, y, z attrs.
+            travel_z:   Instrument-tip Z to hold during XY travel, in the
+                        same user space as ``position.z``.
         """
         instr = self._resolve_instrument(instrument)
         x, y, z = self._resolve_position(position)
@@ -60,33 +62,28 @@ class Board:
         gantry_x = x - instr.offset_x
         gantry_y = y - instr.offset_y
         gantry_z = z - instr.depth
+        gantry_travel_z = (
+            travel_z - instr.depth if travel_z is not None else None
+        )
         self.logger.info(
             "Moving %s to (%.3f, %.3f, %.3f) → gantry (%.3f, %.3f, %.3f)",
             instr.name, x, y, z, gantry_x, gantry_y, gantry_z,
         )
-        self.gantry.move_to(gantry_x, gantry_y, gantry_z)
+        self.gantry.move_to(gantry_x, gantry_y, gantry_z, travel_z=gantry_travel_z)
 
     def move_to_labware(
         self,
         instrument: str | BaseInstrument,
         labware: Position,
     ) -> None:
-        """Safely travel *instrument* to the approach height above a
-        labware target.
+        """Travel *instrument* to the approach height above a labware target.
 
-        Two-step sequence:
-          1. **Retract.** If the tip is currently below
-             ``labware.z + safe_approach_height``, lift at the current
-             XY first so XY travel never drags through labware.
-          2. **Travel.** Move to (labware.x, labware.y,
-             labware.z + safe_approach_height).
-
-        The instrument ends at approach Z — positioned above the target,
-        not engaged with it. To descend to the action Z, follow up with
-        ``board.move(instrument, (labware.x, labware.y,
-        labware.z + instrument.measurement_height))``. Higher-level
-        commands (``measure``, ``aspirate``, ``scan``, ...) do exactly
-        that: approach → descend → act.
+        Emits a single ``move`` with ``travel_z = labware.z +
+        safe_approach_height``. The gantry lifts/lowers to approach Z at
+        the current XY, travels XY at approach Z, and ends above the
+        target — not engaged with it. Higher-level commands
+        (``measure``, ``aspirate``, ``scan``, ...) follow up with a raw
+        ``board.move`` to descend to ``measurement_height``.
 
         Args:
             instrument: Name or instance.
@@ -97,14 +94,8 @@ class Board:
         """
         instr = self._resolve_instrument(instrument)
         x, y, z = self._resolve_position(labware)
-        # Finite-xyz guarding happens inside self.move (below) — no need to
-        # double-validate here.
         approach_z = z + instr.safe_approach_height
-
-        current_tip_x, current_tip_y, current_tip_z = self._current_tip_position(instr)
-        if current_tip_z < approach_z - _Z_TOLERANCE_MM:
-            self.move(instr, (current_tip_x, current_tip_y, approach_z))
-        self.move(instr, (x, y, approach_z))
+        self.move(instr, (x, y, approach_z), travel_z=approach_z)
 
     def _validate_finite_xyz(self, x: float, y: float, z: float, instr_name: str) -> None:
         for label, value in (("x", x), ("y", y), ("z", z)):
@@ -112,35 +103,6 @@ class Board:
                 raise ValueError(
                     f"non-finite {label}={value} for instrument {instr_name!r}."
                 )
-
-    def _current_tip_position(
-        self, instr: BaseInstrument,
-    ) -> tuple[float, float, float]:
-        """Read gantry coordinates and convert to instrument tip (x, y, z)."""
-        try:
-            current = self.gantry.get_coordinates()
-        except Exception as exc:
-            raise RuntimeError(
-                f"Failed to read gantry coordinates while planning a move "
-                f"for instrument {instr.name!r}: {exc}"
-            ) from exc
-        try:
-            gantry_x, gantry_y, gantry_z = current["x"], current["y"], current["z"]
-        except (KeyError, TypeError) as exc:
-            raise RuntimeError(
-                f"gantry.get_coordinates() returned unexpected shape "
-                f"{current!r} for instrument {instr.name!r}."
-            ) from exc
-        if not all(math.isfinite(v) for v in (gantry_x, gantry_y, gantry_z)):
-            raise RuntimeError(
-                f"Gantry reports non-finite coordinates {current!r} for "
-                f"instrument {instr.name!r}."
-            )
-        return (
-            gantry_x + instr.offset_x,
-            gantry_y + instr.offset_y,
-            gantry_z + instr.depth,
-        )
 
     def object_position(
         self, obj: str | BaseInstrument | Any,

--- a/src/board/board.py
+++ b/src/board/board.py
@@ -59,6 +59,10 @@ class Board:
         instr = self._resolve_instrument(instrument)
         x, y, z = self._resolve_position(position)
         self._validate_finite_xyz(x, y, z, instr.name)
+        if travel_z is not None and not math.isfinite(travel_z):
+            raise ValueError(
+                f"non-finite travel_z={travel_z} for instrument {instr.name!r}."
+            )
         gantry_x = x - instr.offset_x
         gantry_y = y - instr.offset_y
         gantry_z = z - instr.depth

--- a/src/gantry/gantry.py
+++ b/src/gantry/gantry.py
@@ -134,18 +134,37 @@ class Gantry:
             self.logger.error("Error homing gantry: %s", exc)
             raise
 
-    def move_to(self, x: float, y: float, z: float) -> None:
-        """Move to absolute user-space coordinates."""
+    def move_to(
+        self,
+        x: float,
+        y: float,
+        z: float,
+        travel_z: Optional[float] = None,
+    ) -> None:
+        """Move to absolute user-space coordinates.
+
+        ``travel_z`` (user space), if given, becomes the Z during XY
+        travel: the gantry lifts/lowers to it at the current XY before
+        moving XY, then descends/ascends to the target Z. This is how
+        higher layers (Board, protocol commands) express "travel above
+        this labware" without the mill baking in a machine-wide retract.
+        """
         if self._offline:
             self._offline_coords = {"x": x, "y": y, "z": z}
             return
         assert self._mill is not None
         try:
             machine_x, machine_y, machine_z = to_machine_coordinates(x, y, z)
-            self._mill.safe_move(
-                x_coord=machine_x,
-                y_coord=machine_y,
-                z_coord=machine_z,
+            machine_travel_z = (
+                to_machine_coordinates(0.0, 0.0, travel_z)[2]
+                if travel_z is not None
+                else None
+            )
+            self._mill.move_to_position(
+                x_coordinate=machine_x,
+                y_coordinate=machine_y,
+                z_coordinate=machine_z,
+                travel_z=machine_travel_z,
             )
         except (
             MillConnectionError,
@@ -279,13 +298,6 @@ class Gantry:
         assert self._mill is not None
         if self._mill.ser_mill is not None:
             self._mill.ser_mill.timeout = timeout
-
-    def set_safe_z(self, z: float) -> None:
-        """Set the clearance height used by Mill.safe_move for XY travel."""
-        if self._offline:
-            return
-        assert self._mill is not None
-        self._mill.max_z_height = z
 
     def zero_coordinates(self) -> None:
         """Zero the work coordinate system at the current position."""

--- a/src/gantry/gantry.py
+++ b/src/gantry/gantry.py
@@ -150,6 +150,13 @@ class Gantry:
         this labware" without the mill baking in a machine-wide retract.
         """
         if self._offline:
+            if travel_z is not None:
+                # Dry runs only record the final tip pose. Log the transit
+                # height so offline protocol validation can still reason
+                # about approach path (e.g. assert it stays above labware).
+                self.logger.debug(
+                    "Offline move to (%s, %s, %s) via travel_z=%s", x, y, z, travel_z,
+                )
             self._offline_coords = {"x": x, "y": y, "z": z}
             return
         assert self._mill is not None

--- a/src/gantry/gantry_driver/driver.py
+++ b/src/gantry/gantry_driver/driver.py
@@ -78,7 +78,6 @@ class Mill:
         active_connection (bool): True if the connection to the mill is active, False otherwise.
         instrument_manager (InstrumentManager): The instrument manager for the mill.
         working_volume (Coordinates): The working volume of the mill.
-        safe_z_height (float): The safe Z height for clearance moves.
         logger_location (Path): The location of the logger.
         logger (Logger): The logger for the mill.
 
@@ -126,7 +125,6 @@ class Mill:
         self.active_connection = False
         self.instrument_manager: InstrumentManager = InstrumentManager()
         self.working_volume: Coordinates = self.read_working_volume()
-        self.safe_z_height = -10.0  # TODO: set the safe floor height to the max height of any active object on the mill + the pipette length
         self.command_logger = set_up_command_logger(self.logger_location)
         self.interactive_mode = False
         self._wco: Optional[Coordinates] = None
@@ -1106,8 +1104,8 @@ class Mill:
         protocol commands) own their own "safe approach" height instead of
         the mill baking in a machine-wide retract.
 
-        When ``travel_z`` is None, the mill issues a direct move — no Z
-        detour — component-wise below ``safe_z_height`` or diagonal above.
+        When ``travel_z`` is None, the mill issues a direct axis-by-axis
+        move (X, then Y, then Z) — no Z detour, no diagonal interpolation.
 
         Args:
             x_coordinate (float): X coordinate.
@@ -1208,24 +1206,22 @@ class Mill:
         current_coordinates: Coordinates,
         target_coordinates: Coordinates,
     ):
-        """Direct move from current to target.
+        """Direct move from current to target, axis-by-axis.
 
-        Above ``safe_z_height`` the mill combines XY into one diagonal
-        command then descends; below it, each axis moves independently so
-        a low tip can't diagonal into a collision on the way up.
+        Emits one G-code per changed axis in X-then-Y-then-Z order.
+        The mill never commands simultaneous multi-axis (diagonal)
+        motion — combining axes in a single G01 would couple their
+        motion into a straight interpolation that could graze
+        obstacles the caller didn't plan for.
         """
         f = f" F{DEFAULT_FEED_RATE}"
         commands = []
-        if current_coordinates.z >= self.safe_z_height:
-            commands.append(f"G01 X{target_coordinates.x} Y{target_coordinates.y}{f}")
+        if target_coordinates.x != current_coordinates.x:
+            commands.append(f"G01 X{target_coordinates.x}{f}")
+        if target_coordinates.y != current_coordinates.y:
+            commands.append(f"G01 Y{target_coordinates.y}{f}")
+        if target_coordinates.z != current_coordinates.z:
             commands.append(f"G01 Z{target_coordinates.z}{f}")
-        else:
-            if target_coordinates.x != current_coordinates.x:
-                commands.append(f"G01 X{target_coordinates.x}{f}")
-            if target_coordinates.y != current_coordinates.y:
-                commands.append(f"G01 Y{target_coordinates.y}{f}")
-            if target_coordinates.z != current_coordinates.z:
-                commands.append(f"G01 Z{target_coordinates.z}{f}")
         return commands
 
     def _generate_transit_commands(
@@ -1234,22 +1230,22 @@ class Mill:
         target_coordinates: Coordinates,
         travel_z: float,
     ):
-        """Transit via ``travel_z``: lift → XY at travel_z → descend.
+        """Transit via ``travel_z``, axis-by-axis: lift → X → Y → descend.
 
         Each step is emitted only when it would produce actual motion,
-        so a move already at ``travel_z`` skips the lift, a same-XY move
-        skips the XY step, and a final Z matching ``travel_z`` skips the
-        descent.
+        so a move already at ``travel_z`` skips the lift, a same-X
+        (or same-Y) move skips that axis, and a final Z matching
+        ``travel_z`` skips the descent. X and Y always move in
+        separate G-codes — no diagonal.
         """
         f = f" F{DEFAULT_FEED_RATE}"
         commands = []
         if current_coordinates.z != travel_z:
             commands.append(f"G01 Z{travel_z}{f}")
-        if (
-            target_coordinates.x != current_coordinates.x
-            or target_coordinates.y != current_coordinates.y
-        ):
-            commands.append(f"G01 X{target_coordinates.x} Y{target_coordinates.y}{f}")
+        if target_coordinates.x != current_coordinates.x:
+            commands.append(f"G01 X{target_coordinates.x}{f}")
+        if target_coordinates.y != current_coordinates.y:
+            commands.append(f"G01 Y{target_coordinates.y}{f}")
         if target_coordinates.z != travel_z:
             commands.append(f"G01 Z{target_coordinates.z}{f}")
         return commands

--- a/src/gantry/gantry_driver/driver.py
+++ b/src/gantry/gantry_driver/driver.py
@@ -79,7 +79,6 @@ class Mill:
         instrument_manager (InstrumentManager): The instrument manager for the mill.
         working_volume (Coordinates): The working volume of the mill.
         safe_z_height (float): The safe Z height for clearance moves.
-        max_z_height (float): The maximum Z height after homing.
         logger_location (Path): The location of the logger.
         logger (Logger): The logger for the mill.
 
@@ -105,10 +104,8 @@ class Mill:
         grbl_settings(): Get the GRBL settings of the mill.
         set_grbl_setting(setting, value): Set a GRBL setting of the mill.
         current_coordinates(instrument): Get the current coordinates of the mill.
-        move_to_safe_position(): Move the mill to its current x,y location and z = 0.
-        move_to_position(x, y, z, coordinates, instrument): Move the mill to the specified coordinates.
+        move_to_position(x, y, z, coordinates, instrument, travel_z): Move the mill to the specified coordinates, optionally via a given XY-travel Z.
         update_offset(instrument, offset_x, offset_y, offset_z): Update the offset in the config file.
-        safe_move(x_coord, y_coord, z_coord, coordinates, instrument, second_z_cord, second_z_cord_feed): Move the mill to the specified coordinates using only horizontal (xy) and vertical movements.
     """
 
     def __init__(self, port: Optional[str] = None):
@@ -130,7 +127,6 @@ class Mill:
         self.instrument_manager: InstrumentManager = InstrumentManager()
         self.working_volume: Coordinates = self.read_working_volume()
         self.safe_z_height = -10.0  # TODO: set the safe floor height to the max height of any active object on the mill + the pipette length
-        self.max_z_height = 0.0
         self.command_logger = set_up_command_logger(self.logger_location)
         self.interactive_mode = False
         self._wco: Optional[Coordinates] = None
@@ -162,18 +158,6 @@ class Mill:
         self.home()
         self.set_feed_rate(5000)
         self.clear_buffers()
-        self.check_max_z_height()
-
-    def check_max_z_height(self):
-        """
-        After homing, if there are no axes offset (G54-G59), the working coordinates should be 0,0,0.
-        If there are axes offset, the working coordinates should be the offset values.
-
-        For this function, if after homing the z coordinate is not 0, then the max z height is set to the current z coordinate.
-        """
-        current_coordinates = self.current_coordinates()
-        if current_coordinates.z != 0:
-            self.max_z_height = current_coordinates.z
 
     def locate_mill_over_serial(self, port: Optional[str] = None) -> Tuple[serial.Serial, str]:
         """
@@ -1103,10 +1087,6 @@ class Mill:
         else:
             return mill_center
 
-    def move_to_safe_position(self) -> str:
-        """Move the mill to its current x,y location and the max z height."""
-        return self.execute_command(f"G01 Z{self.max_z_height}")
-
     def move_to_position(
         self,
         x_coordinate: float = 0.00,
@@ -1114,9 +1094,20 @@ class Mill:
         z_coordinate: float = 0.00,
         coordinates: Coordinates = None,
         instrument: str = "center",
-    ) -> Coordinates:
+        travel_z: Optional[float] = None,
+    ) -> None:
         """
         Move the mill to the specified coordinates.
+
+        When ``travel_z`` is provided, XY travel happens at that Z rather
+        than whatever Z the tip is currently at. The sequence becomes:
+        lift/lower to ``travel_z`` at current XY, XY travel at ``travel_z``,
+        then descend/ascend to the target Z. This lets callers (Board,
+        protocol commands) own their own "safe approach" height instead of
+        the mill baking in a machine-wide retract.
+
+        When ``travel_z`` is None, the mill issues a direct move — no Z
+        detour — component-wise below ``safe_z_height`` or diagonal above.
 
         Args:
             x_coordinate (float): X coordinate.
@@ -1124,9 +1115,7 @@ class Mill:
             z_coordinate (float): Z coordinate.
             coordinates (Coordinates): Target coordinates object (overrides x/y/z params).
             instrument (str): Instrument to move (default: "center").
-
-        Returns:
-            Coordinates: Current coordinates after the move, or None.
+            travel_z (float): Machine-space Z to hold during XY travel.
         """
         goto = (
             Coordinates(x=x_coordinate, y=y_coordinate, z=z_coordinate)
@@ -1148,61 +1137,20 @@ class Mill:
                 y_coordinate,
                 z_coordinate,
             )
-            return current_coordinates
+            return
 
         self._log_target_coordinates(target_coordinates)
         self._validate_target_coordinates(target_coordinates)
-        commands = self._generate_movement_commands(
-            current_coordinates, target_coordinates
-        )
-        for cmd in commands:
-            self.execute_command(cmd)
-        return None
 
-    def move_to_positions(
-        self,
-        coordinates: List[Coordinates],
-        instrument: str = "center",
-        safe_move_required: bool = True,
-    ) -> None:
-        """
-        Move the mill to the specified list of coordinate locations safely.
-        Each movement ensures proper Z-axis clearance before horizontal movements.
-
-        Args:
-            coordinates (List[Coordinates]): List of target coordinates to move to in sequence.
-            instrument (str): The instrument being used (default: "center").
-            safe_move_required (bool): Whether to enforce safe movement patterns (default: True).
-        """
-        current_coordinates = self.current_coordinates()
-        offsets = self.instrument_manager.get_offset(instrument)
-        commands = []
-
-        for target in coordinates:
-            target_coordinates = self._calculate_target_coordinates(
-                target, current_coordinates, offsets
+        if travel_z is None:
+            commands = self._generate_movement_commands(
+                current_coordinates, target_coordinates
             )
-
-            self._validate_target_coordinates(target_coordinates)
-
-            if self._is_already_at_target(target_coordinates, current_coordinates):
-                self.logger.debug(
-                    "%s is already at target coordinates [%s, %s, %s]",
-                    instrument,
-                    target_coordinates.x,
-                    target_coordinates.y,
-                    target_coordinates.z,
-                )
-                continue
-
-            commands.extend(
-                self._generate_movement_commands(
-                    current_coordinates, target_coordinates
-                )
+        else:
+            travel_z_offset = travel_z + offsets.z
+            commands = self._generate_transit_commands(
+                current_coordinates, target_coordinates, travel_z_offset
             )
-
-            current_coordinates = target_coordinates
-
         for cmd in commands:
             self.execute_command(cmd)
 
@@ -1216,88 +1164,6 @@ class Mill:
         )
 
         self.instrument_manager.update_instrument(instrument, new_offset)
-
-    def safe_move(
-        self,
-        x_coord=None,
-        y_coord=None,
-        z_coord=None,
-        coordinates: Coordinates = None,
-        instrument: str = "center",
-        second_z_cord: float = None,
-        second_z_cord_feed: float = 2000,
-    ) -> Coordinates:
-        """
-        Move the mill to the specified coordinates using only horizontal (xy) and vertical movements.
-
-        Args:
-            x_coord (float): X coordinate.
-            y_coord (float): Y coordinate.
-            z_coord (float): Z coordinate.
-            coordinates (Coordinates): Target coordinates object (overrides x/y/z params).
-            instrument (str): The instrument to move to the specified coordinates.
-            second_z_cord (float): The second z coordinate to move to.
-            second_z_cord_feed (float): The feed rate to use when moving to the second z coordinate.
-
-        Returns:
-            Coordinates: Current center coordinates.
-        """
-        if not isinstance(instrument, str):
-            try:
-                instrument = instrument.value
-            except AttributeError:
-                raise ValueError("Invalid instrument") from None
-        commands = []
-        goto = (
-            Coordinates(x=x_coord, y=y_coord, z=z_coord)
-            if not coordinates
-            else coordinates
-        )
-        offsets = self.instrument_manager.get_offset(instrument)
-        current_coordinates = self.current_coordinates()
-
-        target_coordinates = self._calculate_target_coordinates(
-            goto, current_coordinates, offsets
-        )
-        self._validate_target_coordinates(target_coordinates)
-        if self._is_already_at_target(target_coordinates, current_coordinates):
-            self.logger.debug(
-                "%s is already at the target coordinates of [%s, %s, %s]",
-                instrument,
-                x_coord,
-                y_coord,
-                z_coord,
-            )
-            return current_coordinates
-
-        self._log_target_coordinates(target_coordinates)
-        move_to_zero = False
-        if self.__should_move_to_safe_position_first(
-            current_coordinates, target_coordinates, self.max_z_height
-        ):
-            self.logger.debug("Moving to Z=%s first", self.max_z_height)
-            commands.append(f"G01 Z{self.max_z_height} F{DEFAULT_FEED_RATE}")
-            move_to_zero = True
-        else:
-            self.logger.debug("Not moving to Z=%s first", self.max_z_height)
-
-        commands.extend(
-            self._generate_movement_commands(
-                current_coordinates, target_coordinates, move_to_zero
-            )
-        )
-
-        if second_z_cord is not None:
-            # Adjust the second z coordinate according to the instrument offsets
-            second_z_cord += offsets.z
-
-            commands.append(f"G01 Z{second_z_cord} F{second_z_cord_feed}")
-            commands.append(f"F{DEFAULT_FEED_RATE}")
-
-        for cmd in commands:
-            self.execute_command(cmd)
-
-        return self.current_coordinates()
 
     def _is_already_at_target(
         self, goto: Coordinates, current_coordinates: Coordinates
@@ -1341,12 +1207,16 @@ class Mill:
         self,
         current_coordinates: Coordinates,
         target_coordinates: Coordinates,
-        move_z_first: bool = False,
     ):
+        """Direct move from current to target.
+
+        Above ``safe_z_height`` the mill combines XY into one diagonal
+        command then descends; below it, each axis moves independently so
+        a low tip can't diagonal into a collision on the way up.
+        """
         f = f" F{DEFAULT_FEED_RATE}"
         commands = []
-        if current_coordinates.z >= self.safe_z_height or move_z_first:
-            # If above the safe height, allow an XY diagonal move then Z movement
+        if current_coordinates.z >= self.safe_z_height:
             commands.append(f"G01 X{target_coordinates.x} Y{target_coordinates.y}{f}")
             commands.append(f"G01 Z{target_coordinates.z}{f}")
         else:
@@ -1356,36 +1226,30 @@ class Mill:
                 commands.append(f"G01 Y{target_coordinates.y}{f}")
             if target_coordinates.z != current_coordinates.z:
                 commands.append(f"G01 Z{target_coordinates.z}{f}")
-            if (
-                target_coordinates.z == current_coordinates.z and move_z_first
-            ):
-                commands.append(f"G01 Z{target_coordinates.z}{f}")
-
         return commands
 
-    def __should_move_to_safe_position_first(
+    def _generate_transit_commands(
         self,
-        current: Coordinates,
-        destination: Coordinates,
-        safe_height_floor: Optional[float] = None,
+        current_coordinates: Coordinates,
+        target_coordinates: Coordinates,
+        travel_z: float,
     ):
+        """Transit via ``travel_z``: lift → XY at travel_z → descend.
+
+        Each step is emitted only when it would produce actual motion,
+        so a move already at ``travel_z`` skips the lift, a same-XY move
+        skips the XY step, and a final Z matching ``travel_z`` skips the
+        descent.
         """
-        Determine if the mill should move to self.max_z_height before moving to the specified coordinates.
-
-        Args:
-            current (Coordinates): Current coordinates.
-            destination (Coordinates): Target coordinates.
-            safe_height_floor (float): Safe floor height.
-
-        Returns:
-            bool: True if the mill should move to self.max_z_height first, False otherwise.
-        """
-        if safe_height_floor is None:
-            safe_height_floor = self.safe_z_height
-        if current.z >= self.max_z_height or current.z >= safe_height_floor:
-            return False
-
-        if current.x != destination.x or current.y != destination.y:
-            return True
-
-        return False
+        f = f" F{DEFAULT_FEED_RATE}"
+        commands = []
+        if current_coordinates.z != travel_z:
+            commands.append(f"G01 Z{travel_z}{f}")
+        if (
+            target_coordinates.x != current_coordinates.x
+            or target_coordinates.y != current_coordinates.y
+        ):
+            commands.append(f"G01 X{target_coordinates.x} Y{target_coordinates.y}{f}")
+        if target_coordinates.z != travel_z:
+            commands.append(f"G01 Z{target_coordinates.z}{f}")
+        return commands

--- a/src/gantry/gantry_driver/mock.py
+++ b/src/gantry/gantry_driver/mock.py
@@ -46,13 +46,11 @@ class MockMill(RealMill):
     gcode_parameters(): Simulate getting G-code parameters.
     gcode_parser_state(): Simulate getting G-code parser state.
     rinse_electrode(): Simulate rinsing the electrode.
-    move_to_safe_position(): Simulate moving to a safe position.
     move_center_to_position(x_coord, y_coord, z_coord): Simulate moving to a specified position.
     current_coordinates(instrument): Return the tracked current coordinates.
     move_pipette_to_position(x_coord, y_coord, z_coord): Simulate moving the pipette to a specified position.
     move_electrode_to_position(x_coord, y_coord, z_coord): Simulate moving the electrode to a specified position.
     update_offset(offset_type, offset_x, offset_y, offset_z): Simulate updating offsets in the config.
-    safe_move(x_coord, y_coord, z_coord, instrument): Simulate a safe move with horizontal and vertical movements.
     """
 
     def __init__(self):
@@ -60,7 +58,6 @@ class MockMill(RealMill):
         self.logger_location = Path(__file__).parent / "mock_logs"
         self.ser_mill: MockSerialToMill = self.connect_to_mill()
         self.working_volume: Coordinates = Coordinates(x=415.0, y=300.0, z=200.0)
-        self.safe_floor_height = 10.0
 
         self.change_logging_level("DEBUG")
 

--- a/src/instruments/asmi/driver.py
+++ b/src/instruments/asmi/driver.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import statistics
 import time
 from typing import Optional
@@ -19,13 +20,16 @@ _STEP_COUNT_SAFETY_MARGIN = 10
 def _step_count_bound(z_upper: float, z_lower: float, step_size: float) -> int:
     """Upper bound on steps needed to cross [z_lower, z_upper] at step_size.
 
-    Used as a loop-iteration cap to guarantee termination if hardware stalls
-    or rounding otherwise prevents the geometric exit condition from firing.
+    Ceil-based so that a non-integer number of steps still reaches the
+    clamped endpoint. Used as a loop-iteration cap to guarantee termination
+    if hardware stalls or rounding otherwise prevents the geometric exit
+    condition from firing, and — in offline mode — as the actual step count.
     """
     if step_size <= 0:
         raise ValueError(f"step_size must be positive, got {step_size}")
     span = abs(z_upper - z_lower)
-    return int(span / step_size) + _STEP_COUNT_SAFETY_MARGIN
+    raw_steps = math.ceil(span / step_size) if span > 0 else 0
+    return raw_steps + _STEP_COUNT_SAFETY_MARGIN
 
 
 class ASMI(BaseInstrument):

--- a/src/instruments/asmi/driver.py
+++ b/src/instruments/asmi/driver.py
@@ -13,6 +13,19 @@ from instruments.asmi.models import ASMIStatus, MeasurementResult
 
 _DEFAULT_FORCE_THRESHOLD = -100
 _DEFAULT_SENSOR_CHANNELS = [1]
+_STEP_COUNT_SAFETY_MARGIN = 10
+
+
+def _step_count_bound(z_upper: float, z_lower: float, step_size: float) -> int:
+    """Upper bound on steps needed to cross [z_lower, z_upper] at step_size.
+
+    Used as a loop-iteration cap to guarantee termination if hardware stalls
+    or rounding otherwise prevents the geometric exit condition from firing.
+    """
+    if step_size <= 0:
+        raise ValueError(f"step_size must be positive, got {step_size}")
+    span = abs(z_upper - z_lower)
+    return int(span / step_size) + _STEP_COUNT_SAFETY_MARGIN
 
 
 class ASMI(BaseInstrument):
@@ -221,6 +234,7 @@ class ASMI(BaseInstrument):
         force_limit: float | None = None,
         measurement_height: float | None = None,
         baseline_samples: int | None = None,
+        measure_with_return: bool = False,
     ) -> dict:
         """Perform step-by-step indentation at the current XY position.
 
@@ -238,10 +252,16 @@ class ASMI(BaseInstrument):
             force_limit:        Stop when corrected force exceeds this in N (overrides instance default).
             measurement_height: Z to descend to before starting (overrides instance default).
             baseline_samples:   Number of baseline force readings (overrides instance default).
+            measure_with_return:
+                                If True, after descent also step Z back up to
+                                ``measurement_height`` and record each upward sample.
+                                Every sample is tagged with ``direction`` ("down"
+                                on descent, "up" on return).
 
         Returns:
             Dict with keys: measurements, baseline_avg, baseline_std,
-            force_exceeded, data_points.
+            force_exceeded, data_points, measure_with_return. Every entry in
+            ``measurements`` includes a ``direction`` field.
         """
         # Allow protocol method_kwargs to override instance defaults
         _z_target = z_limit if z_limit is not None else self._z_target
@@ -253,7 +273,13 @@ class ASMI(BaseInstrument):
         _baseline_samples = baseline_samples if baseline_samples is not None else self._baseline_samples
 
         if self._offline:
-            return self._offline_indentation(gantry, _z_target, _step_size, _well_top_z)
+            return self._offline_indentation(
+                gantry,
+                _z_target,
+                _step_size,
+                _well_top_z,
+                measure_with_return=measure_with_return,
+            )
 
         coords = gantry.get_coordinates()
         cur_x, cur_y = coords["x"], coords["y"]
@@ -269,8 +295,9 @@ class ASMI(BaseInstrument):
 
         measurements = []
         force_exceeded = False
+        max_steps = _step_count_bound(_well_top_z, _z_target, _step_size)
 
-        while True:
+        for _ in range(max_steps):
             coords = gantry.get_coordinates()
             current_z = coords["z"]
             if current_z <= _z_target:
@@ -287,6 +314,7 @@ class ASMI(BaseInstrument):
                 "z_mm": coords["z"],
                 "raw_force_n": force,
                 "corrected_force_n": corrected,
+                "direction": "down",
             })
 
             if len(measurements) % 10 == 0:
@@ -302,6 +330,48 @@ class ASMI(BaseInstrument):
                 )
                 force_exceeded = True
                 break
+        else:
+            self.logger.warning(
+                "Descent hit iteration cap %d before reaching z_target %.3f",
+                max_steps, _z_target,
+            )
+
+        if measure_with_return and measurements:
+            self.logger.info(
+                "Starting return sweep (%d descent samples collected)",
+                len(measurements),
+            )
+            return_cap = _step_count_bound(_well_top_z, _z_target, _step_size)
+            for _ in range(return_cap):
+                coords = gantry.get_coordinates()
+                current_z = coords["z"]
+                if current_z >= _well_top_z:
+                    break
+                next_z = min(current_z + _step_size, _well_top_z)
+                self._move_z(gantry, cur_x, cur_y, next_z)
+                coords = gantry.get_coordinates()
+                # Break if the gantry did not advance — prevents infinite loop
+                # on stalled axis. get_coordinates reflects the real position.
+                if coords["z"] <= current_z:
+                    self.logger.warning(
+                        "Return sweep aborted: gantry Z did not advance (%.3f)",
+                        current_z,
+                    )
+                    break
+                force = self.get_force_reading()
+                corrected = force - baseline_avg
+                measurements.append({
+                    "timestamp": time.time(),
+                    "z_mm": coords["z"],
+                    "raw_force_n": force,
+                    "corrected_force_n": corrected,
+                    "direction": "up",
+                })
+            else:
+                self.logger.warning(
+                    "Return sweep hit iteration cap %d before reaching well_top_z %.3f",
+                    return_cap, _well_top_z,
+                )
 
         return {
             "measurements": measurements,
@@ -309,25 +379,53 @@ class ASMI(BaseInstrument):
             "baseline_std": baseline_std,
             "force_exceeded": force_exceeded,
             "data_points": len(measurements),
+            "measure_with_return": measure_with_return,
         }
 
-    def _offline_indentation(self, gantry, z_limit, step_size, measurement_height) -> dict:
+    def _offline_indentation(
+        self,
+        gantry,
+        z_limit,
+        step_size,
+        measurement_height,
+        measure_with_return: bool = False,
+    ) -> dict:
         """Fast offline indentation — no idle-wait, synthetic data."""
         coords = gantry.get_coordinates()
         cur_x, cur_y = coords["x"], coords["y"]
         gantry.move_to(cur_x, cur_y, measurement_height)
 
+        # Integer step counting avoids float accumulation drift at loop boundaries.
+        n_down = _step_count_bound(measurement_height, z_limit, step_size) - _STEP_COUNT_SAFETY_MARGIN
         measurements = []
-        z = measurement_height
-        while z > z_limit:
-            z -= step_size
+        for i in range(1, n_down + 1):
+            z = max(measurement_height - i * step_size, z_limit)
             gantry.move_to(cur_x, cur_y, z)
             measurements.append({
                 "timestamp": time.time(),
                 "z_mm": z,
                 "raw_force_n": self._default_force,
                 "corrected_force_n": 0.0,
+                "direction": "down",
             })
+            if z <= z_limit:
+                break
+
+        if measure_with_return:
+            z_bottom = measurements[-1]["z_mm"] if measurements else measurement_height
+            n_up = _step_count_bound(measurement_height, z_bottom, step_size) - _STEP_COUNT_SAFETY_MARGIN
+            for i in range(1, n_up + 1):
+                z = min(z_bottom + i * step_size, measurement_height)
+                gantry.move_to(cur_x, cur_y, z)
+                measurements.append({
+                    "timestamp": time.time(),
+                    "z_mm": z,
+                    "raw_force_n": self._default_force,
+                    "corrected_force_n": 0.0,
+                    "direction": "up",
+                })
+                if z >= measurement_height:
+                    break
 
         return {
             "measurements": measurements,
@@ -335,4 +433,5 @@ class ASMI(BaseInstrument):
             "baseline_std": 0.0,
             "force_exceeded": False,
             "data_points": len(measurements),
+            "measure_with_return": measure_with_return,
         }

--- a/src/instruments/base_instrument.py
+++ b/src/instruments/base_instrument.py
@@ -54,10 +54,11 @@ class BaseInstrument(ABC):
             raise ValueError(
                 f"safe_approach_height ({resolved_safe}) must be >= "
                 f"measurement_height ({measurement_height}) for "
-                f"{self.__class__.__name__}. Otherwise Board.move_to_labware "
-                f"would travel XY below the action Z and the 'lower' step "
-                f"would move the instrument upward — defeating the retract-"
-                f"travel-lower safety guarantee."
+                f"{self.__class__.__name__}. Board.move_to_labware travels "
+                f"XY at safe_approach_height and then descends to "
+                f"measurement_height; if the travel height sits below the "
+                f"action height, that 'descent' would lift the instrument "
+                f"instead — defeating the approach-above-then-descend contract."
             )
         self.name = name or self.__class__.__name__
         self.offset_x = offset_x

--- a/src/protocol_engine/measurements.py
+++ b/src/protocol_engine/measurements.py
@@ -131,18 +131,32 @@ def normalize_measurement(
 
     if isinstance(raw_result, dict) and "measurements" in raw_result:
         steps = raw_result["measurements"]
+        has_direction = any("direction" in s for s in steps)
+        payload = {
+            "z_positions_mm": [s["z_mm"] for s in steps],
+            "raw_forces_n": [s["raw_force_n"] for s in steps],
+            "corrected_forces_n": [s["corrected_force_n"] for s in steps],
+        }
+        if has_direction:
+            # Default missing entries to "down" (legacy pre-dual-sweep payloads)
+            # but warn so callers can detect mid-run corruption where only
+            # part of a return sweep was tagged.
+            if not all("direction" in s for s in steps):
+                import logging
+                logging.getLogger(__name__).warning(
+                    "Partial 'direction' tags in ASMI indentation steps; "
+                    "defaulting missing entries to 'down'",
+                )
+            payload["directions"] = [s.get("direction", "down") for s in steps]
         return InstrumentMeasurement(
             measurement_type=MeasurementType.ASMI_INDENTATION,
-            payload={
-                "z_positions_mm": [s["z_mm"] for s in steps],
-                "raw_forces_n": [s["raw_force_n"] for s in steps],
-                "corrected_forces_n": [s["corrected_force_n"] for s in steps],
-            },
+            payload=payload,
             metadata={
                 "baseline_avg": raw_result.get("baseline_avg", 0.0),
                 "baseline_std": raw_result.get("baseline_std", 0.0),
                 "force_exceeded": raw_result.get("force_exceeded", False),
                 "data_points": raw_result.get("data_points", len(steps)),
+                "measure_with_return": raw_result.get("measure_with_return", False),
                 "instrument_name": instrument_name,
                 "method_name": method_name,
             },

--- a/src/protocol_engine/measurements.py
+++ b/src/protocol_engine/measurements.py
@@ -131,23 +131,24 @@ def normalize_measurement(
 
     if isinstance(raw_result, dict) and "measurements" in raw_result:
         steps = raw_result["measurements"]
-        has_direction = any("direction" in s for s in steps)
+        # Warn when direction tags are partial — mid-run corruption signal.
+        # Current ASMI driver always tags; missing entries default to "down"
+        # for legacy/partial payloads, and directions is always emitted so
+        # downstream consumers see a stable schema.
+        has_any_direction = any("direction" in s for s in steps)
+        has_all_directions = all("direction" in s for s in steps) if steps else True
+        if has_any_direction and not has_all_directions:
+            import logging
+            logging.getLogger(__name__).warning(
+                "Partial 'direction' tags in ASMI indentation steps; "
+                "defaulting missing entries to 'down'",
+            )
         payload = {
             "z_positions_mm": [s["z_mm"] for s in steps],
             "raw_forces_n": [s["raw_force_n"] for s in steps],
             "corrected_forces_n": [s["corrected_force_n"] for s in steps],
+            "directions": [s.get("direction", "down") for s in steps],
         }
-        if has_direction:
-            # Default missing entries to "down" (legacy pre-dual-sweep payloads)
-            # but warn so callers can detect mid-run corruption where only
-            # part of a return sweep was tagged.
-            if not all("direction" in s for s in steps):
-                import logging
-                logging.getLogger(__name__).warning(
-                    "Partial 'direction' tags in ASMI indentation steps; "
-                    "defaulting missing entries to 'down'",
-                )
-            payload["directions"] = [s.get("direction", "down") for s in steps]
         return InstrumentMeasurement(
             measurement_type=MeasurementType.ASMI_INDENTATION,
             payload=payload,

--- a/tests/board/test_board.py
+++ b/tests/board/test_board.py
@@ -148,6 +148,32 @@ class TestBoardMove:
 
         gantry.move_to.assert_called_once_with(140.0, 70.0, 8.0, travel_z=None)
 
+    def test_move_forwards_travel_z_minus_depth_to_gantry(self):
+        """travel_z is an instrument-tip Z; gantry must receive it
+        translated into gantry-frame by subtracting instrument depth —
+        the same transform we apply to target z."""
+        gantry = _mock_gantry()
+        instr = _mock_instrument("pipette", offset_x=0.0, offset_y=0.0, depth=4.0)
+        board = Board(gantry=gantry, instruments={"pipette": instr})
+
+        board.move("pipette", (50.0, 25.0, 10.0), travel_z=30.0)
+
+        # gantry_z = tip_z - depth: target 10-4=6, travel 30-4=26.
+        gantry.move_to.assert_called_once_with(50.0, 25.0, 6.0, travel_z=26.0)
+
+    def test_move_rejects_non_finite_travel_z(self):
+        """travel_z flows straight through to the gantry/mill as raw
+        G-code; an NaN/Inf here would emit `G01 Znan` to GRBL. Guard
+        at the board boundary."""
+        gantry = _mock_gantry()
+        instr = _mock_instrument("probe")
+        board = Board(gantry=gantry, instruments={"probe": instr})
+
+        with pytest.raises(ValueError, match="non-finite travel_z"):
+            board.move("probe", (10.0, 20.0, 5.0), travel_z=float("nan"))
+        with pytest.raises(ValueError, match="non-finite travel_z"):
+            board.move("probe", (10.0, 20.0, 5.0), travel_z=float("inf"))
+
 
 # ─── object_position() tests ─────────────────────────────────────────────────
 

--- a/tests/board/test_board.py
+++ b/tests/board/test_board.py
@@ -92,7 +92,7 @@ class TestBoardMove:
 
         board.move("pipette", (100.0, 50.0, 20.0))
 
-        gantry.move_to.assert_called_once_with(90.0, 45.0, 18.0)
+        gantry.move_to.assert_called_once_with(90.0, 45.0, 18.0, travel_z=None)
 
     def test_move_by_instance_calls_gantry_move_to(self):
         gantry = _mock_gantry()
@@ -101,7 +101,7 @@ class TestBoardMove:
 
         board.move(pip, (100.0, 50.0, 20.0))
 
-        gantry.move_to.assert_called_once_with(90.0, 45.0, 18.0)
+        gantry.move_to.assert_called_once_with(90.0, 45.0, 18.0, travel_z=None)
 
     def test_move_zero_offset_passes_position_through(self):
         gantry = _mock_gantry()
@@ -110,7 +110,7 @@ class TestBoardMove:
 
         board.move("router", (200.0, 100.0, 10.0))
 
-        gantry.move_to.assert_called_once_with(200.0, 100.0, 10.0)
+        gantry.move_to.assert_called_once_with(200.0, 100.0, 10.0, travel_z=None)
 
     def test_move_positive_offset(self):
         """Instrument mounted to the right (+x) of the router."""
@@ -121,7 +121,7 @@ class TestBoardMove:
         board.move("sensor", (50.0, 30.0, 5.0))
 
         # gantry_x = 50 - 15 = 35, gantry_y = 30 - 10 = 20, gantry_z = 5 - 3 = 2
-        gantry.move_to.assert_called_once_with(35.0, 20.0, 2.0)
+        gantry.move_to.assert_called_once_with(35.0, 20.0, 2.0, travel_z=None)
 
     def test_move_unknown_instrument_raises(self):
         board = Board(gantry=_mock_gantry())
@@ -146,7 +146,7 @@ class TestBoardMove:
 
         board.move("pipette", lw)
 
-        gantry.move_to.assert_called_once_with(140.0, 70.0, 8.0)
+        gantry.move_to.assert_called_once_with(140.0, 70.0, 8.0, travel_z=None)
 
 
 # ─── object_position() tests ─────────────────────────────────────────────────
@@ -266,142 +266,82 @@ class TestBoardDisconnectInstruments:
 
 # ─── move_to_labware tests ───────────────────────────────────────────────────
 #
-# move_to_labware ends at the SAFE APPROACH Z — it does NOT descend to
-# the action Z. Commands that need to engage (measure, aspirate, etc.)
-# perform a follow-up raw board.move() to descend. See test_measure_command
-# and test_pipette_commands for descent behavior.
+# move_to_labware issues one gantry.move_to with travel_z = approach Z.
+# The gantry driver does the lift → XY → descent sequence internally
+# from that single call. move_to_labware ends at the approach Z — it
+# does NOT descend to the action Z; commands that need to engage
+# (measure, aspirate, etc.) follow up with a raw board.move() to
+# descend. See test_measure_command and test_pipette_commands for
+# descent behavior.
 
 
 class TestBoardMoveToLabware:
 
-    def test_high_start_single_travel(self):
-        """Gantry already above approach Z: one XY travel move, no retract."""
-        gantry = _mock_gantry(z=100.0)
+    def test_single_gantry_call_with_travel_z(self):
+        """One gantry.move_to call, target xyz at approach Z, travel_z = approach Z."""
+        gantry = _mock_gantry()
         instr = _mock_instrument(measurement_height=3.0, safe_approach_height=3.0)
         board = Board(gantry=gantry, instruments={"sensor": instr})
         board.move_to_labware("sensor", _mock_labware(x=100, y=50, z=20))
 
         assert gantry.move_to.call_count == 1
-        # tip target: (100, 50, 20 + safe_approach=3 = 23)
-        assert gantry.move_to.call_args.args == (100.0, 50.0, 23.0)
+        call = gantry.move_to.call_args
+        # tip target: (100, 50, 20 + safe_approach=3 = 23). travel_z == target z.
+        assert call.args == (100.0, 50.0, 23.0)
+        assert call.kwargs == {"travel_z": 23.0}
 
-    def test_contact_high_start_travel_at_approach(self):
-        """Contact instrument starting high: travel at approach Z. No descent."""
-        gantry = _mock_gantry(z=100.0)
+    def test_contact_instrument_travel_at_approach_above_action(self):
+        """Contact instrument with safe_approach > measurement: travel_z
+        is the approach Z, above the action Z."""
+        gantry = _mock_gantry()
         instr = _mock_instrument(measurement_height=-5.0, safe_approach_height=20.0)
         board = Board(gantry=gantry, instruments={"pipette": instr})
         board.move_to_labware("pipette", _mock_labware(x=100, y=50, z=30))
 
         assert gantry.move_to.call_count == 1
-        assert gantry.move_to.call_args.args == (100.0, 50.0, 50.0)   # approach Z
+        call = gantry.move_to.call_args
+        # approach z = 30 + 20 = 50.
+        assert call.args == (100.0, 50.0, 50.0)
+        assert call.kwargs == {"travel_z": 50.0}
 
-    def test_low_start_retract_then_travel(self):
-        """Gantry at a previous low Z: retract at current XY before XY travel.
-        Simulates the scan well-to-well transition."""
-        gantry = _mock_gantry(x=50.0, y=40.0, z=25.0)
-        instr = _mock_instrument(measurement_height=-5.0, safe_approach_height=20.0)
-        board = Board(gantry=gantry, instruments={"pipette": instr})
-        board.move_to_labware("pipette", _mock_labware(x=100, y=50, z=30))
-
-        assert gantry.move_to.call_count == 2
-        calls = gantry.move_to.call_args_list
-        assert calls[0].args == (50.0, 40.0, 50.0)    # retract at current XY
-        assert calls[1].args == (100.0, 50.0, 50.0)   # travel at approach Z
-
-    def test_applies_instrument_xy_offsets(self):
-        gantry = _mock_gantry(z=100.0)
+    def test_applies_instrument_xy_offsets_and_depth(self):
+        """Instrument offsets shift gantry coords; depth shifts both
+        target z and travel_z since both are tip-frame Zs."""
+        gantry = _mock_gantry()
         instr = _mock_instrument(
-            offset_x=10.0, offset_y=-5.0,
+            offset_x=10.0, offset_y=-5.0, depth=2.0,
             measurement_height=0.0, safe_approach_height=15.0,
         )
         board = Board(gantry=gantry, instruments={"probe": instr})
         board.move_to_labware("probe", _mock_labware(x=100, y=50, z=30))
 
-        args = gantry.move_to.call_args.args
-        # Gantry X = labware.x - offset_x; Y likewise.
-        assert args == (90.0, 55.0, 45.0)  # approach z = 30 + 15 = 45
+        call = gantry.move_to.call_args
+        # approach tip z = 30 + 15 = 45; gantry z = 45 - depth(2) = 43.
+        # gantry x = 100 - 10 = 90; gantry y = 50 - (-5) = 55.
+        assert call.args == (90.0, 55.0, 43.0)
+        assert call.kwargs == {"travel_z": 43.0}
 
     def test_accepts_tuple_position(self):
-        gantry = _mock_gantry(z=100.0)
+        gantry = _mock_gantry()
         instr = _mock_instrument(measurement_height=2.0, safe_approach_height=2.0)
         board = Board(gantry=gantry, instruments={"probe": instr})
         board.move_to_labware("probe", (50.0, 40.0, 10.0))
 
         assert gantry.move_to.call_count == 1
-        assert gantry.move_to.call_args.args == (50.0, 40.0, 12.0)
-
-    def test_scan_well_transition_pattern(self):
-        """End-to-end scan flow: after measuring at W1 at action z, the
-        next move_to_labware for W2 does retract → travel to W2 approach z.
-        (Descent to W2's action z happens in the scan command via board.move.)"""
-        gantry = _mock_gantry(x=100.0, y=50.0, z=25.0)   # at W1 action z
-        instr = _mock_instrument(measurement_height=-5.0, safe_approach_height=20.0)
-        board = Board(gantry=gantry, instruments={"pipette": instr})
-        board.move_to_labware("pipette", _mock_labware(x=110, y=50, z=30))
-
-        calls = gantry.move_to.call_args_list
-        assert [c.args for c in calls] == [
-            (100.0, 50.0, 50.0),   # retract at W1.xy to W2's approach z
-            (110.0, 50.0, 50.0),   # travel XY at approach z
-        ]
-
-    def test_retract_accounts_for_nonzero_depth_and_offsets(self):
-        """When depth != 0 and offsets != 0, the retract's tip XY must
-        account for instrument offsets and its tip Z for depth."""
-        gantry = _mock_gantry(x=30.0, y=40.0, z=15.0)
-        instr = _mock_instrument(
-            offset_x=5.0, offset_y=-3.0, depth=10.0,
-            measurement_height=-5.0, safe_approach_height=30.0,
-        )
-        board = Board(gantry=gantry, instruments={"pipette": instr})
-        board.move_to_labware("pipette", _mock_labware(x=100, y=50, z=20))
-
-        calls = gantry.move_to.call_args_list
-        # Step 1: retract at CURRENT tip XY (30+5, 40-3 = 35, 37) to approach_z=50.
-        #   Gantry target x = 35-5 = 30, y = 37-(-3) = 40, z = 50-10 = 40.
-        assert calls[0].args == (30.0, 40.0, 40.0)
-        # Step 2: travel to target XY at approach_z.
-        #   Gantry target x = 100-5 = 95, y = 50-(-3) = 53, z = 40.
-        assert calls[1].args == (95.0, 53.0, 40.0)
-
-    def test_does_not_retract_when_exactly_at_approach_z(self):
-        """Boundary: current_tip_z == approach_z, no retract."""
-        gantry = _mock_gantry(x=100.0, y=50.0, z=50.0)
-        instr = _mock_instrument(measurement_height=-5.0, safe_approach_height=20.0)
-        board = Board(gantry=gantry, instruments={"pipette": instr})
-        board.move_to_labware("pipette", _mock_labware(x=100, y=50, z=30))
-
-        assert gantry.move_to.call_count == 1
-        assert gantry.move_to.call_args.args == (100.0, 50.0, 50.0)
-
-    def test_does_not_retract_for_submicron_offset(self):
-        """Boundary: tip Z below approach by < 1e-4 mm (gantry encoder
-        resolution) must not trigger a spurious micro-retract."""
-        gantry = _mock_gantry(x=100.0, y=50.0, z=49.99995)
-        instr = _mock_instrument(measurement_height=-5.0, safe_approach_height=20.0)
-        board = Board(gantry=gantry, instruments={"pipette": instr})
-        board.move_to_labware("pipette", _mock_labware(x=100, y=50, z=30))
-        assert gantry.move_to.call_count == 1   # no retract
-
-    def test_retracts_when_below_tolerance(self):
-        """Boundary: tip Z below approach by 1e-3 mm (above tolerance)
-        must retract."""
-        gantry = _mock_gantry(x=100.0, y=50.0, z=49.999)
-        instr = _mock_instrument(measurement_height=-5.0, safe_approach_height=20.0)
-        board = Board(gantry=gantry, instruments={"pipette": instr})
-        board.move_to_labware("pipette", _mock_labware(x=100, y=50, z=30))
-        assert gantry.move_to.call_count == 2   # retract + travel
+        call = gantry.move_to.call_args
+        assert call.args == (50.0, 40.0, 12.0)
+        assert call.kwargs == {"travel_z": 12.0}
 
     def test_rejects_nan_position_z(self):
         """NaN in position z is caught (via Board.move's validation)."""
-        gantry = _mock_gantry(z=100.0)
+        gantry = _mock_gantry()
         instr = _mock_instrument(measurement_height=0.0, safe_approach_height=0.0)
         board = Board(gantry=gantry, instruments={"probe": instr})
         with pytest.raises(ValueError, match="non-finite"):
             board.move_to_labware("probe", (10.0, 20.0, float("nan")))
 
     def test_rejects_infinite_position_x(self):
-        gantry = _mock_gantry(z=100.0)
+        gantry = _mock_gantry()
         instr = _mock_instrument(measurement_height=0.0, safe_approach_height=0.0)
         board = Board(gantry=gantry, instruments={"probe": instr})
         with pytest.raises(ValueError, match="non-finite"):
@@ -411,26 +351,8 @@ class TestBoardMoveToLabware:
         """Raw Board.move (used for descent in commands) must also guard
         against NaN/Inf coords — otherwise a bad measurement_height could
         silently send the gantry to a non-finite Z."""
-        gantry = _mock_gantry(z=100.0)
+        gantry = _mock_gantry()
         instr = _mock_instrument()
         board = Board(gantry=gantry, instruments={"probe": instr})
         with pytest.raises(ValueError, match="non-finite"):
             board.move("probe", (10.0, 20.0, float("nan")))
-
-    def test_wraps_gantry_read_failure(self):
-        """If gantry.get_coordinates() raises, surface a clear error."""
-        gantry = MagicMock()
-        gantry.get_coordinates.side_effect = RuntimeError("serial timeout")
-        instr = _mock_instrument(measurement_height=0.0, safe_approach_height=0.0)
-        board = Board(gantry=gantry, instruments={"probe": instr})
-        with pytest.raises(RuntimeError, match="read gantry coordinates"):
-            board.move_to_labware("probe", _mock_labware(x=10, y=20, z=30))
-
-    def test_rejects_gantry_nan_coordinates(self):
-        """If the gantry reports NaN, refuse to plan a move."""
-        gantry = MagicMock()
-        gantry.get_coordinates.return_value = {"x": 0.0, "y": 0.0, "z": float("nan")}
-        instr = _mock_instrument(measurement_height=0.0, safe_approach_height=0.0)
-        board = Board(gantry=gantry, instruments={"probe": instr})
-        with pytest.raises(RuntimeError, match="non-finite coordinates"):
-            board.move_to_labware("probe", _mock_labware(x=10, y=20, z=30))

--- a/tests/gantry/driver/test_gantry_driver.py
+++ b/tests/gantry/driver/test_gantry_driver.py
@@ -42,7 +42,6 @@ class TestCNCDriverLogic(unittest.TestCase):
         """Test generation of G-code commands."""
         # Setup mock mill with basic config
         mill = Mill()
-        mill.max_z_height = 0.0
         mill.safe_z_height = -5.0
         
         # Test 1: Simple XY move (current Z is safe)
@@ -73,6 +72,50 @@ class TestCNCDriverLogic(unittest.TestCase):
         self.assertIn("G01 X10.0 F2000", commands_unsafe)
         self.assertIn("G01 Y10.0 F2000", commands_unsafe)
         self.assertNotIn("G01 X10.0 Y10.0", commands_unsafe)
+
+    @patch('gantry.gantry_driver.driver.serial.Serial')
+    @patch('gantry.gantry_driver.driver.set_up_mill_logger')
+    @patch('gantry.gantry_driver.driver.set_up_command_logger')
+    def test_generate_transit_commands_lifts_traverses_descends(
+        self, mock_cmd_logger, mock_mill_logger, mock_serial,
+    ):
+        """Transit: lift to travel_z, XY travel, descend to target z.
+
+        Models an inter-well scan move: start low at well_i, hop over to
+        well_j at safe-approach height, end there. The mill must emit
+        three G-code lines in that order.
+        """
+        mill = Mill()
+        mill.safe_z_height = -10.0
+
+        current = Coordinates(-100.0, -50.0, -78.0)  # machine space, at well_i action z
+        target = Coordinates(-110.0, -50.0, -85.0)   # well_j at approach z
+        commands = mill._generate_transit_commands(current, target, travel_z=-85.0)
+
+        self.assertEqual(commands, [
+            "G01 Z-85.0 F2000",         # lift to travel_z at well_i.xy
+            "G01 X-110.0 Y-50.0 F2000", # XY travel at travel_z
+            # target.z == travel_z, final descent skipped.
+        ])
+
+    @patch('gantry.gantry_driver.driver.serial.Serial')
+    @patch('gantry.gantry_driver.driver.set_up_mill_logger')
+    @patch('gantry.gantry_driver.driver.set_up_command_logger')
+    def test_generate_transit_commands_skips_lift_when_already_at_travel_z(
+        self, mock_cmd_logger, mock_mill_logger, mock_serial,
+    ):
+        """Already at travel_z: no lift, just XY then descent to target."""
+        mill = Mill()
+        mill.safe_z_height = -10.0
+
+        current = Coordinates(-100.0, -50.0, -85.0)
+        target = Coordinates(-110.0, -50.0, -90.0)
+        commands = mill._generate_transit_commands(current, target, travel_z=-85.0)
+
+        self.assertEqual(commands, [
+            "G01 X-110.0 Y-50.0 F2000",
+            "G01 Z-90.0 F2000",
+        ])
 
     @patch('gantry.gantry_driver.driver.serial.Serial')
     @patch('gantry.gantry_driver.driver.set_up_mill_logger')

--- a/tests/gantry/driver/test_gantry_driver.py
+++ b/tests/gantry/driver/test_gantry_driver.py
@@ -38,40 +38,37 @@ class TestCNCDriverLogic(unittest.TestCase):
     @patch('gantry.gantry_driver.driver.serial.Serial')
     @patch('gantry.gantry_driver.driver.set_up_mill_logger')
     @patch('gantry.gantry_driver.driver.set_up_command_logger')
-    def test_generate_movement_commands(self, mock_cmd_logger, mock_mill_logger, mock_serial):
-        """Test generation of G-code commands."""
-        # Setup mock mill with basic config
+    def test_generate_movement_commands_are_axis_by_axis(self, mock_cmd_logger, mock_mill_logger, mock_serial):
+        """Direct moves emit X, Y, Z on separate G-code lines — never a
+        combined ``G01 X… Y…`` interpolation. The mill must not command
+        simultaneous multi-axis motion so callers own every straight
+        segment of the path."""
         mill = Mill()
-        mill.safe_z_height = -5.0
-        
-        # Test 1: Simple XY move (current Z is safe)
-        current = Coordinates(0, 0, 0) # At safe height (0 >= -5)
-        target = Coordinates(10, 10, 0)
-        
+
+        current = Coordinates(0.0, 0.0, 0.0)
+        target = Coordinates(10.0, 20.0, -5.0)
         commands = mill._generate_movement_commands(current, target)
-        # Should be diagonal move
-        self.assertIn("G01 X10.0 Y10.0 F2000", commands)
-        self.assertIn("G01 Z0.0 F2000", commands)
-        
-        # Test 2: Move where current Z is unsafe (e.g. deep in a well)
-        # However, _generate_movement_commands logic in current driver:
-        # if current.z >= safe_height: diagonal move
-        # else: separate moves
-        
-        current_unsafe = Coordinates(0, 0, -10) # Below safe height of -5
-        target_unsafe = Coordinates(10, 10, -10)
-        
-        commands_unsafe = mill._generate_movement_commands(current_unsafe, target_unsafe)
-        # Should NOT have diagonal move X Y together if strictly following "non-safe" path logic?
-        # Looking at code: 
-        # else:
-        #   append X..
-        #   append Y..
-        #   append Z..
-        
-        self.assertIn("G01 X10.0 F2000", commands_unsafe)
-        self.assertIn("G01 Y10.0 F2000", commands_unsafe)
-        self.assertNotIn("G01 X10.0 Y10.0", commands_unsafe)
+
+        self.assertEqual(commands, [
+            "G01 X10.0 F2000",
+            "G01 Y20.0 F2000",
+            "G01 Z-5.0 F2000",
+        ])
+        # Regression guard: no combined-XY command anywhere.
+        self.assertFalse(any("Y" in c and "X" in c for c in commands))
+
+    @patch('gantry.gantry_driver.driver.serial.Serial')
+    @patch('gantry.gantry_driver.driver.set_up_mill_logger')
+    @patch('gantry.gantry_driver.driver.set_up_command_logger')
+    def test_generate_movement_commands_skips_unchanged_axes(self, mock_cmd_logger, mock_mill_logger, mock_serial):
+        """Only the axes that actually changed get a G-code line."""
+        mill = Mill()
+
+        current = Coordinates(0.0, 5.0, -5.0)
+        target = Coordinates(10.0, 5.0, -5.0)  # only X changes
+        commands = mill._generate_movement_commands(current, target)
+
+        self.assertEqual(commands, ["G01 X10.0 F2000"])
 
     @patch('gantry.gantry_driver.driver.serial.Serial')
     @patch('gantry.gantry_driver.driver.set_up_mill_logger')
@@ -79,22 +76,21 @@ class TestCNCDriverLogic(unittest.TestCase):
     def test_generate_transit_commands_lifts_traverses_descends(
         self, mock_cmd_logger, mock_mill_logger, mock_serial,
     ):
-        """Transit: lift to travel_z, XY travel, descend to target z.
+        """Transit: lift → X → Y → (descend skipped when target_z == travel_z).
 
-        Models an inter-well scan move: start low at well_i, hop over to
-        well_j at safe-approach height, end there. The mill must emit
-        three G-code lines in that order.
+        Models an inter-well scan hop. X and Y always ship as separate
+        G-code lines so no diagonal motion is ever commanded.
         """
         mill = Mill()
-        mill.safe_z_height = -10.0
 
-        current = Coordinates(-100.0, -50.0, -78.0)  # machine space, at well_i action z
-        target = Coordinates(-110.0, -50.0, -85.0)   # well_j at approach z
+        current = Coordinates(-100.0, -50.0, -78.0)  # well_i action z
+        target = Coordinates(-110.0, -60.0, -85.0)   # well_j approach z
         commands = mill._generate_transit_commands(current, target, travel_z=-85.0)
 
         self.assertEqual(commands, [
-            "G01 Z-85.0 F2000",         # lift to travel_z at well_i.xy
-            "G01 X-110.0 Y-50.0 F2000", # XY travel at travel_z
+            "G01 Z-85.0 F2000",    # lift
+            "G01 X-110.0 F2000",   # X alone
+            "G01 Y-60.0 F2000",    # Y alone
             # target.z == travel_z, final descent skipped.
         ])
 
@@ -104,16 +100,85 @@ class TestCNCDriverLogic(unittest.TestCase):
     def test_generate_transit_commands_skips_lift_when_already_at_travel_z(
         self, mock_cmd_logger, mock_mill_logger, mock_serial,
     ):
-        """Already at travel_z: no lift, just XY then descent to target."""
+        """Already at travel_z: no lift, just X (Y unchanged) then descent."""
         mill = Mill()
-        mill.safe_z_height = -10.0
 
         current = Coordinates(-100.0, -50.0, -85.0)
-        target = Coordinates(-110.0, -50.0, -90.0)
+        target = Coordinates(-110.0, -50.0, -90.0)  # Y unchanged
         commands = mill._generate_transit_commands(current, target, travel_z=-85.0)
 
         self.assertEqual(commands, [
-            "G01 X-110.0 Y-50.0 F2000",
+            "G01 X-110.0 F2000",
+            "G01 Z-90.0 F2000",
+        ])
+
+    @patch('gantry.gantry_driver.driver.serial.Serial')
+    @patch('gantry.gantry_driver.driver.set_up_mill_logger')
+    @patch('gantry.gantry_driver.driver.set_up_command_logger')
+    def test_generate_transit_commands_skips_xy_when_target_xy_matches_current(
+        self, mock_cmd_logger, mock_mill_logger, mock_serial,
+    ):
+        """Same-XY transit: lift then descend — neither X nor Y emits."""
+        mill = Mill()
+
+        current = Coordinates(-100.0, -50.0, -78.0)
+        target = Coordinates(-100.0, -50.0, -90.0)
+        commands = mill._generate_transit_commands(current, target, travel_z=-85.0)
+
+        self.assertEqual(commands, [
+            "G01 Z-85.0 F2000",
+            "G01 Z-90.0 F2000",
+        ])
+
+    @patch('gantry.gantry_driver.driver.serial.Serial')
+    @patch('gantry.gantry_driver.driver.set_up_mill_logger')
+    @patch('gantry.gantry_driver.driver.set_up_command_logger')
+    def test_generate_transit_commands_emits_all_four_steps(
+        self, mock_cmd_logger, mock_mill_logger, mock_serial,
+    ):
+        """Lift → X → Y → descend, all four fire when every axis changes
+        and travel_z differs from both current.z and target.z."""
+        mill = Mill()
+
+        current = Coordinates(-100.0, -50.0, -78.0)
+        target = Coordinates(-110.0, -60.0, -90.0)
+        commands = mill._generate_transit_commands(current, target, travel_z=-85.0)
+
+        self.assertEqual(commands, [
+            "G01 Z-85.0 F2000",    # lift
+            "G01 X-110.0 F2000",   # X alone
+            "G01 Y-60.0 F2000",    # Y alone
+            "G01 Z-90.0 F2000",    # descend
+        ])
+
+    @patch('gantry.gantry_driver.driver.serial.Serial')
+    @patch('gantry.gantry_driver.driver.set_up_mill_logger')
+    @patch('gantry.gantry_driver.driver.set_up_command_logger')
+    def test_move_to_position_with_travel_z_emits_ordered_commands(
+        self, mock_cmd_logger, mock_mill_logger, mock_serial,
+    ):
+        """End-to-end: move_to_position(..., travel_z=...) routes
+        through _generate_transit_commands and emits lift → X → Y →
+        descend in order. instrument='center' has zero offsets, so
+        the emitted travel_z matches the input."""
+        mill = Mill()
+        mill.ser_mill = MagicMock()
+        mill.current_coordinates = MagicMock(
+            return_value=Coordinates(-100.0, -50.0, -78.0),
+        )
+
+        sent = []
+        mill.execute_command = lambda cmd: sent.append(cmd) or "ok"
+
+        mill.move_to_position(
+            x_coordinate=-110.0, y_coordinate=-60.0, z_coordinate=-90.0,
+            travel_z=-85.0,
+        )
+
+        self.assertEqual(sent, [
+            "G01 Z-85.0 F2000",
+            "G01 X-110.0 F2000",
+            "G01 Y-60.0 F2000",
             "G01 Z-90.0 F2000",
         ])
 

--- a/tests/gantry/driver/test_wpos_enforcement.py
+++ b/tests/gantry/driver/test_wpos_enforcement.py
@@ -107,10 +107,11 @@ class TestWposEnforcement(unittest.TestCase):
 
         mill.move_to_position(x_coordinate=-10.0, y_coordinate=-10.0, z_coordinate=0.0)
 
-        xy_commands = [c for c in commands_sent if "X" in c and "Y" in c]
-        self.assertTrue(len(xy_commands) > 0)
-        self.assertIn("X-10.0", xy_commands[0])
-        self.assertIn("Y-10.0", xy_commands[0])
+        # X and Y are always emitted on separate lines — no diagonal.
+        x_commands = [c for c in commands_sent if "X-10.0" in c and "Y" not in c]
+        y_commands = [c for c in commands_sent if "Y-10.0" in c and "X" not in c]
+        self.assertEqual(len(x_commands), 1)
+        self.assertEqual(len(y_commands), 1)
 
 
 if __name__ == '__main__':

--- a/tests/gantry/driver/test_wpos_enforcement.py
+++ b/tests/gantry/driver/test_wpos_enforcement.py
@@ -95,8 +95,8 @@ class TestWposEnforcement(unittest.TestCase):
         self.assertEqual(float(match.group(2)), -200.0)
         self.assertEqual(float(match.group(3)), -80.0)
 
-    def test_safe_move_uses_wpos_internally(self):
-        """Verify safe_move's internal current_coordinates call gets WPos."""
+    def test_move_to_position_uses_wpos_internally(self):
+        """Verify move_to_position's internal current_coordinates call gets WPos."""
         mill = self._make_mill()
         mill.config["$10"] = "0"
         mill.ser_mill.write = MagicMock()
@@ -105,7 +105,7 @@ class TestWposEnforcement(unittest.TestCase):
         commands_sent = []
         mill.execute_command = lambda cmd: commands_sent.append(cmd) or "ok"
 
-        mill.safe_move(x_coord=-10.0, y_coord=-10.0, z_coord=0.0)
+        mill.move_to_position(x_coordinate=-10.0, y_coordinate=-10.0, z_coordinate=0.0)
 
         xy_commands = [c for c in commands_sent if "X" in c and "Y" in c]
         self.assertTrue(len(xy_commands) > 0)

--- a/tests/gantry/test_gantry.py
+++ b/tests/gantry/test_gantry.py
@@ -22,14 +22,27 @@ class TestGantry(unittest.TestCase):
         mock_mill.connect_to_mill.assert_called_with(port=None)
 
     @patch("gantry.gantry.Mill")
-    def test_move_delegates_to_safe_move(self, mock_mill_cls):
+    def test_move_delegates_to_move_to_position(self, mock_mill_cls):
         mock_mill = mock_mill_cls.return_value
         gantry = Gantry(config=self.config)
         gantry.move_to(10, 20, 30)
-        mock_mill.safe_move.assert_called_with(
-            x_coord=-10.0,
-            y_coord=-20.0,
-            z_coord=-30.0,
+        mock_mill.move_to_position.assert_called_with(
+            x_coordinate=-10.0,
+            y_coordinate=-20.0,
+            z_coordinate=-30.0,
+            travel_z=None,
+        )
+
+    @patch("gantry.gantry.Mill")
+    def test_move_with_travel_z_passes_through_translated(self, mock_mill_cls):
+        mock_mill = mock_mill_cls.return_value
+        gantry = Gantry(config=self.config)
+        gantry.move_to(10, 20, 30, travel_z=50)
+        mock_mill.move_to_position.assert_called_with(
+            x_coordinate=-10.0,
+            y_coordinate=-20.0,
+            z_coordinate=-30.0,
+            travel_z=-50.0,
         )
 
     @patch("gantry.gantry.Mill")
@@ -136,7 +149,7 @@ class TestGantry(unittest.TestCase):
     @patch("gantry.gantry.Mill")
     def test_move_to_raises_on_command_error(self, mock_mill_cls):
         mock_mill = mock_mill_cls.return_value
-        mock_mill.safe_move.side_effect = CommandExecutionError("move failed")
+        mock_mill.move_to_position.side_effect = CommandExecutionError("move failed")
         gantry = Gantry(config=self.config)
         with self.assertRaises(CommandExecutionError):
             gantry.move_to(10, 20, 30)
@@ -144,7 +157,7 @@ class TestGantry(unittest.TestCase):
     @patch("gantry.gantry.Mill")
     def test_move_to_does_not_catch_unexpected_errors(self, mock_mill_cls):
         mock_mill = mock_mill_cls.return_value
-        mock_mill.safe_move.side_effect = RuntimeError("unexpected")
+        mock_mill.move_to_position.side_effect = RuntimeError("unexpected")
         gantry = Gantry(config=self.config)
         with self.assertRaises(RuntimeError):
             gantry.move_to(10, 20, 30)

--- a/tests/gantry/test_gantry_translation.py
+++ b/tests/gantry/test_gantry_translation.py
@@ -26,10 +26,11 @@ def _config() -> dict:
 def test_move_to_translates_user_to_machine_coordinates(mock_mill_cls) -> None:
     gantry = Gantry(config=_config())
     gantry.move_to(150.0, 100.0, 40.0)
-    mock_mill_cls.return_value.safe_move.assert_called_once_with(
-        x_coord=-150.0,
-        y_coord=-100.0,
-        z_coord=-40.0,
+    mock_mill_cls.return_value.move_to_position.assert_called_once_with(
+        x_coordinate=-150.0,
+        y_coordinate=-100.0,
+        z_coordinate=-40.0,
+        travel_z=None,
     )
 
 
@@ -70,10 +71,24 @@ def test_zero_home_coordinates_stay_zero(mock_mill_cls) -> None:
 def test_boundary_translation(mock_mill_cls) -> None:
     gantry = Gantry(config=_config())
     gantry.move_to(300.0, 200.0, 80.0)
-    mock_mill_cls.return_value.safe_move.assert_called_once_with(
-        x_coord=-300.0,
-        y_coord=-200.0,
-        z_coord=-80.0,
+    mock_mill_cls.return_value.move_to_position.assert_called_once_with(
+        x_coordinate=-300.0,
+        y_coordinate=-200.0,
+        z_coordinate=-80.0,
+        travel_z=None,
+    )
+
+
+@patch("gantry.gantry.Mill")
+def test_travel_z_translates_to_machine_space(mock_mill_cls) -> None:
+    """travel_z is given in user space; mill receives machine space."""
+    gantry = Gantry(config=_config())
+    gantry.move_to(150.0, 100.0, 40.0, travel_z=70.0)
+    mock_mill_cls.return_value.move_to_position.assert_called_once_with(
+        x_coordinate=-150.0,
+        y_coordinate=-100.0,
+        z_coordinate=-40.0,
+        travel_z=-70.0,
     )
 
 

--- a/tests/instruments/test_asmi.py
+++ b/tests/instruments/test_asmi.py
@@ -123,11 +123,12 @@ class TestASMIOffline(unittest.TestCase):
         self.assertAlmostEqual(up_z[-1], -10.0, places=6)
 
     def test_indentation_offline_return_no_float_drift(self):
-        """Return loop must terminate even when step_size doesn't divide the range evenly."""
+        """Descent must reach z_limit and return must hit measurement_height exactly,
+        even when step_size doesn't divide the range evenly."""
         from gantry.gantry import Gantry
         gantry = Gantry(offline=True)
 
-        # 0.03 does not evenly divide 2.0 (66.66 steps).
+        # 0.03 does not evenly divide 2.0 (66.67 steps → ceil to 67).
         result = self.asmi.indentation(
             gantry,
             z_limit=-12.0,
@@ -136,8 +137,30 @@ class TestASMIOffline(unittest.TestCase):
             measure_with_return=True,
         )
 
+        down_z = [s["z_mm"] for s in result["measurements"] if s["direction"] == "down"]
         up_z = [s["z_mm"] for s in result["measurements"] if s["direction"] == "up"]
+        self.assertAlmostEqual(down_z[-1], -12.0, places=6)
         self.assertAlmostEqual(up_z[-1], -10.0, places=6)
+
+    def test_indentation_offline_step_larger_than_span_takes_one_step(self):
+        """When step_size exceeds the span, one clamped step must still occur."""
+        from gantry.gantry import Gantry
+        gantry = Gantry(offline=True)
+
+        result = self.asmi.indentation(
+            gantry,
+            z_limit=-10.05,
+            measurement_height=-10.0,
+            step_size=0.5,
+            measure_with_return=True,
+        )
+
+        down_z = [s["z_mm"] for s in result["measurements"] if s["direction"] == "down"]
+        up_z = [s["z_mm"] for s in result["measurements"] if s["direction"] == "up"]
+        self.assertEqual(len(down_z), 1)
+        self.assertAlmostEqual(down_z[0], -10.05, places=6)
+        self.assertEqual(len(up_z), 1)
+        self.assertAlmostEqual(up_z[0], -10.0, places=6)
 
 
 class _FakeOnlineGantry:

--- a/tests/instruments/test_asmi.py
+++ b/tests/instruments/test_asmi.py
@@ -1,6 +1,7 @@
 """Tests for the ASMI instrument driver (offline mode)."""
 
 import unittest
+from unittest.mock import patch
 
 from instruments.asmi.driver import ASMI
 from instruments.asmi.models import ASMIStatus, MeasurementResult
@@ -47,13 +48,10 @@ class TestASMIOffline(unittest.TestCase):
         """Offline indentation should return synthetic measurements quickly."""
         from gantry.gantry import Gantry
         gantry = Gantry(offline=True)
-        # Use small range for fast test
-        self.asmi._z_target = -12.0
-        self.asmi._well_top_z = -10.0
-        self.asmi._step_size = 0.1
-        self.asmi._safe_z = -5.0
 
-        result = self.asmi.indentation(gantry)
+        result = self.asmi.indentation(
+            gantry, z_limit=-12.0, measurement_height=-10.0, step_size=0.1,
+        )
 
         self.assertIn("measurements", result)
         self.assertIn("baseline_avg", result)
@@ -61,6 +59,171 @@ class TestASMIOffline(unittest.TestCase):
         self.assertEqual(result["data_points"], len(result["measurements"]))
         self.assertGreater(result["data_points"], 0)
         self.assertFalse(result["force_exceeded"])
+        self.assertFalse(result["measure_with_return"])
+
+    def test_indentation_offline_with_return_includes_directions(self):
+        """Return-mode indentation should include both down and up direction samples."""
+        from gantry.gantry import Gantry
+        gantry = Gantry(offline=True)
+
+        result = self.asmi.indentation(
+            gantry,
+            z_limit=-12.0,
+            measurement_height=-10.0,
+            step_size=0.1,
+            measure_with_return=True,
+        )
+
+        self.assertTrue(result["measure_with_return"])
+        directions = [step.get("direction") for step in result["measurements"]]
+        self.assertIn("down", directions)
+        self.assertIn("up", directions)
+
+    def test_indentation_offline_emits_direction_unconditionally(self):
+        """Every sample should carry a direction tag, even without return mode."""
+        from gantry.gantry import Gantry
+        gantry = Gantry(offline=True)
+
+        result = self.asmi.indentation(
+            gantry, z_limit=-12.0, measurement_height=-10.0, step_size=0.1,
+        )
+
+        self.assertGreater(len(result["measurements"]), 0)
+        for step in result["measurements"]:
+            self.assertEqual(step["direction"], "down")
+
+    def test_indentation_offline_return_preserves_ordering_and_monotonicity(self):
+        """All down samples must precede all up samples; z descends then ascends."""
+        from gantry.gantry import Gantry
+        gantry = Gantry(offline=True)
+
+        result = self.asmi.indentation(
+            gantry,
+            z_limit=-12.0,
+            measurement_height=-10.0,
+            step_size=0.1,
+            measure_with_return=True,
+        )
+
+        steps = result["measurements"]
+        directions = [s["direction"] for s in steps]
+        last_down = max(i for i, d in enumerate(directions) if d == "down")
+        first_up = min(i for i, d in enumerate(directions) if d == "up")
+        self.assertLess(last_down, first_up)
+
+        down_z = [s["z_mm"] for s in steps if s["direction"] == "down"]
+        up_z = [s["z_mm"] for s in steps if s["direction"] == "up"]
+        # Down: each z strictly lower than the previous (gantry goes more negative).
+        for prev, curr in zip(down_z, down_z[1:]):
+            self.assertLess(curr, prev)
+        # Up: each z strictly higher than the previous.
+        for prev, curr in zip(up_z, up_z[1:]):
+            self.assertGreater(curr, prev)
+        # Return terminates at measurement_height (well top), never overshoots.
+        self.assertAlmostEqual(up_z[-1], -10.0, places=6)
+
+    def test_indentation_offline_return_no_float_drift(self):
+        """Return loop must terminate even when step_size doesn't divide the range evenly."""
+        from gantry.gantry import Gantry
+        gantry = Gantry(offline=True)
+
+        # 0.03 does not evenly divide 2.0 (66.66 steps).
+        result = self.asmi.indentation(
+            gantry,
+            z_limit=-12.0,
+            measurement_height=-10.0,
+            step_size=0.03,
+            measure_with_return=True,
+        )
+
+        up_z = [s["z_mm"] for s in result["measurements"] if s["direction"] == "up"]
+        self.assertAlmostEqual(up_z[-1], -10.0, places=6)
+
+
+class _FakeOnlineGantry:
+    """Minimal gantry stub for exercising ASMI online indentation loops."""
+
+    def __init__(self, start_z: float):
+        self._z = start_z
+
+    def get_coordinates(self) -> dict:
+        return {"x": 0.0, "y": 0.0, "z": self._z}
+
+    def get_status(self) -> str:
+        return "Idle"
+
+    def move_to(self, x: float, y: float, z: float) -> None:
+        self._z = z
+
+
+class TestASMIOnlineIndentation(unittest.TestCase):
+    """Exercise the non-offline indentation code path with mocked hardware I/O."""
+
+    def _make_online_asmi(self) -> ASMI:
+        asmi = ASMI(offline=False, default_force=0.0)
+        asmi._offline = False
+        return asmi
+
+    def test_online_indentation_with_return_records_both_directions(self):
+        asmi = self._make_online_asmi()
+        gantry = _FakeOnlineGantry(start_z=-10.0)
+
+        with patch.object(asmi, "get_baseline_force", return_value=(0.0, 0.0)), \
+             patch.object(asmi, "get_force_reading", return_value=0.1):
+            result = asmi.indentation(
+                gantry,
+                z_limit=-10.5,
+                measurement_height=-10.0,
+                step_size=0.1,
+                force_limit=100.0,
+                baseline_samples=1,
+                measure_with_return=True,
+            )
+
+        directions = [s["direction"] for s in result["measurements"]]
+        self.assertIn("down", directions)
+        self.assertIn("up", directions)
+        up_z = [s["z_mm"] for s in result["measurements"] if s["direction"] == "up"]
+        self.assertAlmostEqual(up_z[-1], -10.0, places=6)
+
+    def test_online_return_terminates_even_if_gantry_stalls(self):
+        """If gantry Z never advances, return loop must bail via iteration cap, not spin."""
+        asmi = self._make_online_asmi()
+
+        class StalledGantry(_FakeOnlineGantry):
+            def move_to(self, x, y, z):
+                # Simulate a stalled axis: position never changes.
+                pass
+
+        gantry = StalledGantry(start_z=-10.0)
+        # Prime descent by letting z reach z_limit on the first real move; we
+        # only need _some_ descent measurement to trigger the return block.
+        original_move = _FakeOnlineGantry.move_to
+        call_count = {"n": 0}
+
+        def move_once_then_stall(self, x, y, z):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                original_move(self, x, y, z)  # initial descend to measurement_height
+            elif call_count["n"] == 2:
+                original_move(self, x, y, z)  # one descent step
+            # subsequent moves no-op → stall during return
+
+        with patch.object(StalledGantry, "move_to", move_once_then_stall), \
+             patch.object(asmi, "get_baseline_force", return_value=(0.0, 0.0)), \
+             patch.object(asmi, "get_force_reading", return_value=0.0):
+            result = asmi.indentation(
+                gantry,
+                z_limit=-10.1,
+                measurement_height=-10.0,
+                step_size=0.1,
+                force_limit=100.0,
+                baseline_samples=1,
+                measure_with_return=True,
+            )
+
+        # The test's real requirement: the call returns, i.e. no infinite loop.
+        self.assertIn("measurements", result)
 
 
 class TestASMIOnlineRequiresHardware(unittest.TestCase):

--- a/tests/protocol_engine/test_measurements.py
+++ b/tests/protocol_engine/test_measurements.py
@@ -58,3 +58,73 @@ class TestNormalizeMeasurement:
                 method_name="measure",
                 raw_result=object(),
             )
+
+    def test_normalize_asmi_indentation_without_return_mode(self):
+        raw_result = {
+            "measurements": [
+                {"z_mm": -73.01, "raw_force_n": 0.10, "corrected_force_n": 0.01},
+                {"z_mm": -73.02, "raw_force_n": 0.11, "corrected_force_n": 0.02},
+            ],
+            "baseline_avg": 0.09,
+            "baseline_std": 0.001,
+            "force_exceeded": False,
+            "data_points": 2,
+        }
+
+        measurement = normalize_measurement(
+            instrument_name="asmi",
+            method_name="indentation",
+            raw_result=raw_result,
+        )
+
+        assert measurement.measurement_type == MeasurementType.ASMI_INDENTATION
+        assert measurement.payload["z_positions_mm"] == [-73.01, -73.02]
+        assert "directions" not in measurement.payload
+        assert measurement.metadata["measure_with_return"] is False
+
+    def test_normalize_asmi_indentation_with_return_mode(self):
+        raw_result = {
+            "measurements": [
+                {"z_mm": -73.01, "raw_force_n": 0.10, "corrected_force_n": 0.01, "direction": "down"},
+                {"z_mm": -73.02, "raw_force_n": 0.11, "corrected_force_n": 0.02, "direction": "down"},
+                {"z_mm": -73.01, "raw_force_n": 0.09, "corrected_force_n": 0.00, "direction": "up"},
+            ],
+            "baseline_avg": 0.09,
+            "baseline_std": 0.001,
+            "force_exceeded": False,
+            "data_points": 3,
+            "measure_with_return": True,
+        }
+
+        measurement = normalize_measurement(
+            instrument_name="asmi",
+            method_name="indentation",
+            raw_result=raw_result,
+        )
+
+        assert measurement.measurement_type == MeasurementType.ASMI_INDENTATION
+        assert measurement.payload["directions"] == ["down", "down", "up"]
+        assert measurement.metadata["measure_with_return"] is True
+
+    def test_normalize_asmi_partial_direction_defaults_missing_to_down(self):
+        """Mixed-tag step lists (one sample missing ``direction``) must default missing entries to 'down'."""
+        raw_result = {
+            "measurements": [
+                {"z_mm": -73.01, "raw_force_n": 0.10, "corrected_force_n": 0.01, "direction": "down"},
+                {"z_mm": -73.02, "raw_force_n": 0.11, "corrected_force_n": 0.02},
+                {"z_mm": -73.01, "raw_force_n": 0.09, "corrected_force_n": 0.00, "direction": "up"},
+            ],
+            "baseline_avg": 0.09,
+            "baseline_std": 0.001,
+            "force_exceeded": False,
+            "data_points": 3,
+            "measure_with_return": True,
+        }
+
+        measurement = normalize_measurement(
+            instrument_name="asmi",
+            method_name="indentation",
+            raw_result=raw_result,
+        )
+
+        assert measurement.payload["directions"] == ["down", "down", "up"]

--- a/tests/protocol_engine/test_measurements.py
+++ b/tests/protocol_engine/test_measurements.py
@@ -79,7 +79,9 @@ class TestNormalizeMeasurement:
 
         assert measurement.measurement_type == MeasurementType.ASMI_INDENTATION
         assert measurement.payload["z_positions_mm"] == [-73.01, -73.02]
-        assert "directions" not in measurement.payload
+        # Legacy untagged payloads default to "down" so the normalized
+        # schema always exposes directions.
+        assert measurement.payload["directions"] == ["down", "down"]
         assert measurement.metadata["measure_with_return"] is False
 
     def test_normalize_asmi_indentation_with_return_mode(self):

--- a/tests/protocol_engine/test_scan_command.py
+++ b/tests/protocol_engine/test_scan_command.py
@@ -175,6 +175,25 @@ class TestScanCommand:
         # action_z = well.z + measurement_height = 75 + 3 = 78.
         assert descent_zs == [78.0, 78.0, 78.0, 78.0]
 
+    def test_descent_move_does_not_pass_travel_z(self):
+        """Regression guard: the raw descent after move_to_labware must
+        NOT pass a travel_z. If it did, the gantry would lift to
+        travel_z before descending to action z — reintroducing the
+        original bug where the tip detoured up instead of going
+        straight down from safe_approach_height to measurement_height."""
+        from protocol_engine.commands.scan import scan
+
+        plate = _make_2x2_plate()
+        sensor = _make_sensor(measurement_height=3.0, safe_approach_height=10.0)
+        ctx = _mock_context(plate=plate, sensor=sensor)
+
+        scan(ctx, plate="plate_1", instrument="uvvis", method="measure")
+
+        for call in ctx.board.move.call_args_list:
+            assert call.kwargs.get("travel_z") is None, (
+                f"descent move must not pass travel_z; got {call.kwargs!r}"
+            )
+
     def test_approach_then_descend_then_method_per_well(self):
         """Per-well call order: move_to_labware -> move (descent) -> method."""
         from protocol_engine.commands.scan import scan


### PR DESCRIPTION
## Summary
- Scan over a well plate was forcing a full-height retract to `max_z_height` on every inter-well XY travel (`measure_z → approach_z → max_z → XY → approach_z → measure_z`), even though `Board.move_to_labware` had already established a safe travel Z via `safe_approach_height`. The redundant detour lived in `Mill.safe_move` — the wrong layer of the stack.
- `Mill.move_to_position(..., travel_z=None)` is now the single move primitive: with `travel_z` given, the mill emits lift → XY → descend; with `travel_z=None`, a direct move. `Board.move_to_labware` collapses to one call with `travel_z = labware.z + safe_approach_height`.
- Deleted: `Mill.safe_move`, `Mill.move_to_positions` (plural, zero callers), `Mill.move_to_safe_position`, `Mill.__should_move_to_safe_position_first`, `Mill.check_max_z_height`, `Mill.max_z_height`, `Gantry.set_safe_z`. SHARC is the only known external caller of `set_safe_z`; fixed in parallel PR BU-KABlab/SHARC#new.

## Observed vs. fixed scan sequence
Between two wells (safe_approach_height=10, measurement_height=3, well.z=75, max_z=100):

| Step | Before | After |
|---|---|---|
| 1 | retract to 85 | lift to 85 |
| 2 | **up to 100 (max_z)** | — |
| 3 | XY at 100 | XY at 85 |
| 4 | down to 85 | — |
| 5 | down to 78 | down to 78 |

## Test plan
- [x] pytest — 871 passed, 15 skipped. One pre-existing failure (test_distribution_artifacts_include_registry_yaml, bdist_wheel env issue, unrelated).
- [x] Board.move_to_labware → single gantry.move_to(target, travel_z=approach_z) call.
- [x] Mill._generate_transit_commands emits lift → XY → descent in order, skips no-ops.
- [x] Gantry.move_to(..., travel_z=…) translates user-space to machine-space on both target and travel_z.
- [ ] Hardware verification on UV-Vis CCS scan — needs operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)