### PR TITLE
fix: add safe approach z to raw moves

### DIFF
--- a/src/board/board.py
+++ b/src/board/board.py
@@ -42,6 +42,7 @@ class Board:
         self,
         instrument: str | BaseInstrument,
         position: Position,
+        safe_approach_z: float | None = None,
     ) -> None:
         """Move the gantry so that *instrument* arrives at *position*.
 
@@ -53,6 +54,10 @@ class Board:
         Args:
             instrument: Name (key in ``self.instruments``) or instance.
             position:   (x, y, z) tuple or labware object with x, y, z attrs.
+            safe_approach_z:
+                        Optional instrument-space Z height to use during XY
+                        travel. When set, it is translated into gantry space
+                        using the instrument depth before commanding the move.
         """
         instr = self._resolve_instrument(instrument)
         x, y, z = self._resolve_position(position)
@@ -60,11 +65,23 @@ class Board:
         gantry_x = x - instr.offset_x
         gantry_y = y - instr.offset_y
         gantry_z = z - instr.depth
+        gantry_safe_approach_z = (
+            None if safe_approach_z is None else safe_approach_z - instr.depth
+        )
         self.logger.info(
             "Moving %s to (%.3f, %.3f, %.3f) → gantry (%.3f, %.3f, %.3f)",
             instr.name, x, y, z, gantry_x, gantry_y, gantry_z,
         )
-        self.gantry.move_to(gantry_x, gantry_y, gantry_z)
+        if gantry_safe_approach_z is None:
+            self.gantry.move_to(gantry_x, gantry_y, gantry_z)
+            return
+
+        self.gantry.move_to(
+            gantry_x,
+            gantry_y,
+            gantry_z,
+            safe_approach_z=gantry_safe_approach_z,
+        )
 
     def move_to_labware(
         self,

--- a/src/gantry/gantry.py
+++ b/src/gantry/gantry.py
@@ -134,13 +134,33 @@ class Gantry:
             self.logger.error("Error homing gantry: %s", exc)
             raise
 
-    def move_to(self, x: float, y: float, z: float) -> None:
-        """Move to absolute user-space coordinates."""
+    def move_to(
+        self,
+        x: float,
+        y: float,
+        z: float,
+        safe_approach_z: float | None = None,
+    ) -> None:
+        """Move to absolute user-space coordinates.
+
+        When ``safe_approach_z`` is provided, XY travel is routed through
+        that user-space Z height instead of the mill's default max-Z safe
+        move behavior.
+        """
         if self._offline:
             self._offline_coords = {"x": x, "y": y, "z": z}
             return
         assert self._mill is not None
         try:
+            if safe_approach_z is not None:
+                self._move_to_with_safe_approach(
+                    x=x,
+                    y=y,
+                    z=z,
+                    safe_approach_z=safe_approach_z,
+                )
+                return
+
             machine_x, machine_y, machine_z = to_machine_coordinates(x, y, z)
             self._mill.safe_move(
                 x_coord=machine_x,
@@ -157,6 +177,49 @@ class Gantry:
                 "Error moving gantry to (%s, %s, %s): %s", x, y, z, exc
             )
             raise
+
+    def _move_to_with_safe_approach(
+        self,
+        x: float,
+        y: float,
+        z: float,
+        safe_approach_z: float,
+    ) -> None:
+        """Move via a caller-provided user-space approach Z."""
+        assert self._mill is not None
+        current = self.get_coordinates()
+        target_machine_x, target_machine_y, target_machine_z = to_machine_coordinates(
+            x, y, z
+        )
+        xy_changed = current["x"] != x or current["y"] != y
+
+        if xy_changed and current["z"] < safe_approach_z:
+            current_machine_x, current_machine_y, approach_machine_z = (
+                to_machine_coordinates(
+                    current["x"],
+                    current["y"],
+                    safe_approach_z,
+                )
+            )
+            self._mill.move_to_position(
+                x_coordinate=current_machine_x,
+                y_coordinate=current_machine_y,
+                z_coordinate=approach_machine_z,
+            )
+
+        if xy_changed:
+            _, _, approach_machine_z = to_machine_coordinates(x, y, safe_approach_z)
+            self._mill.move_to_position(
+                x_coordinate=target_machine_x,
+                y_coordinate=target_machine_y,
+                z_coordinate=approach_machine_z,
+            )
+
+        self._mill.move_to_position(
+            x_coordinate=target_machine_x,
+            y_coordinate=target_machine_y,
+            z_coordinate=target_machine_z,
+        )
 
     def jog(
         self,

--- a/src/gantry/offline.py
+++ b/src/gantry/offline.py
@@ -30,7 +30,13 @@ class OfflineGantry:
     def unlock(self) -> None:
         pass
 
-    def move_to(self, x: float, y: float, z: float) -> None:
+    def move_to(
+        self,
+        x: float,
+        y: float,
+        z: float,
+        safe_approach_z: float | None = None,
+    ) -> None:
         self._coords = {"x": x, "y": y, "z": z}
 
     def get_coordinates(self) -> dict[str, float]:

--- a/tests/board/test_board.py
+++ b/tests/board/test_board.py
@@ -148,6 +148,20 @@ class TestBoardMove:
 
         gantry.move_to.assert_called_once_with(140.0, 70.0, 8.0)
 
+    def test_move_translates_safe_approach_z_with_instrument_depth(self):
+        gantry = _mock_gantry()
+        instr = _mock_instrument("pipette", offset_x=10.0, offset_y=5.0, depth=2.0)
+        board = Board(gantry=gantry, instruments={"pipette": instr})
+
+        board.move("pipette", (100.0, 50.0, 20.0), safe_approach_z=30.0)
+
+        gantry.move_to.assert_called_once_with(
+            90.0,
+            45.0,
+            18.0,
+            safe_approach_z=28.0,
+        )
+
 
 # ─── object_position() tests ─────────────────────────────────────────────────
 

--- a/tests/gantry/test_gantry.py
+++ b/tests/gantry/test_gantry.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 from gantry.gantry import Gantry
 from gantry.gantry_driver.exceptions import (
@@ -30,6 +30,28 @@ class TestGantry(unittest.TestCase):
             x_coord=-10.0,
             y_coord=-20.0,
             z_coord=-30.0,
+        )
+
+    @patch("gantry.gantry.Mill")
+    def test_move_with_safe_approach_sequences_retract_travel_and_descent(
+        self, mock_mill_cls
+    ):
+        mock_mill = mock_mill_cls.return_value
+        mock_mill.current_coordinates.return_value.x = -5.0
+        mock_mill.current_coordinates.return_value.y = -6.0
+        mock_mill.current_coordinates.return_value.z = -7.0
+        gantry = Gantry(config=self.config)
+
+        gantry.move_to(10, 20, 30, safe_approach_z=25)
+
+        mock_mill.safe_move.assert_not_called()
+        self.assertEqual(
+            mock_mill.move_to_position.call_args_list,
+            [
+                call(x_coordinate=-5.0, y_coordinate=-6.0, z_coordinate=-25.0),
+                call(x_coordinate=-10.0, y_coordinate=-20.0, z_coordinate=-25.0),
+                call(x_coordinate=-10.0, y_coordinate=-20.0, z_coordinate=-30.0),
+            ],
         )
 
     @patch("gantry.gantry.Mill")


### PR DESCRIPTION
## Summary
- add an optional `safe_approach_z` to raw `Board.move` / `Gantry.move_to` calls so XY travel can happen at a caller-provided clearance height
- keep the existing default safe-move behavior unchanged when `safe_approach_z` is omitted
- cover the new path with focused board and gantry tests

## Testing
- `python -m pytest -q tests/gantry/test_gantry.py tests/board/test_board.py`
- `python -m pytest -q tests/protocol_engine/test_move_command.py`
