### PR TITLE
fix: require WPos before protocol execution

### DIFF
--- a/src/gantry/gantry_driver/driver.py
+++ b/src/gantry/gantry_driver/driver.py
@@ -352,13 +352,9 @@ class Mill:
         self.read_working_volume()
 
         self.clear_buffers()
-        if initial_status:
-            self._enforce_wpos_mode()
-        else:
-            self.logger.warning(
-                "No initial GRBL status response; skipping WPos enforcement during connect"
-            )
+        self._enforce_wpos_mode()
         self.set_feed_rate(DEFAULT_FEED_RATE)
+        self._verify_work_position_reporting()
         if initial_status:
             self._seed_wco()
         return self.ser_mill
@@ -921,6 +917,23 @@ class Mill:
                 "Could not verify G90 during connect; continuing with existing parser state"
             )
         self.logger.info("WPos mode and absolute positioning enforced")
+
+    def _verify_work_position_reporting(self) -> Coordinates:
+        """Fail connect if GRBL still cannot report work coordinates."""
+        try:
+            coords = self.current_coordinates()
+        except (LocationNotFound, StatusReturnError) as exc:
+            raise MillConnectionError(
+                "Mill did not report a usable WPos after connect"
+            ) from exc
+
+        self.logger.info(
+            "Verified WPos reporting after connect: X=%s Y=%s Z=%s",
+            coords.x,
+            coords.y,
+            coords.z,
+        )
+        return coords
 
     def _seed_wco(self):
         """Poll GRBL status until WCO is reported, then cache it.

--- a/tests/gantry/driver/test_gantry_driver.py
+++ b/tests/gantry/driver/test_gantry_driver.py
@@ -8,6 +8,7 @@ project_root = Path(__file__).parent.parent
 sys.path.append(str(project_root))
 
 from gantry.gantry_driver.driver import Mill, wpos_pattern, mpos_pattern, Coordinates
+from gantry.gantry_driver.exceptions import LocationNotFound, MillConnectionError
 
 class TestCNCDriverLogic(unittest.TestCase):
     
@@ -93,11 +94,37 @@ class TestCNCDriverLogic(unittest.TestCase):
             mill.clear_buffers = MagicMock()
             mill._enforce_wpos_mode = MagicMock()
             mill.set_feed_rate = MagicMock()
+            mill._verify_work_position_reporting = MagicMock()
             mill._seed_wco = MagicMock()
+            mill.read = MagicMock(return_value="<Idle|WPos:0,0,0|FS:0,0>")
             mill.connect_to_mill(port='/dev/test')
             
             self.assertTrue(mill.active_connection)
             self.assertEqual(mill.ser_mill, mock_serial_instance)
+            mill._verify_work_position_reporting.assert_called_once_with()
+
+    @patch('gantry.gantry_driver.driver.serial.Serial')
+    @patch('gantry.gantry_driver.driver.set_up_mill_logger')
+    @patch('gantry.gantry_driver.driver.set_up_command_logger')
+    def test_connect_raises_when_wpos_cannot_be_verified(self, mock_cmd_logger, mock_mill_logger, mock_serial):
+        """Test that connect_to_mill fails when WPos is still unavailable after enforcement."""
+        mock_serial_instance = MagicMock()
+        mock_serial_instance.is_open = True
+        mock_serial.return_value = mock_serial_instance
+
+        with patch.object(Mill, 'locate_mill_over_serial', return_value=(mock_serial_instance, '/dev/test')):
+            mill = Mill()
+            mill.read_mill_config = MagicMock()
+            mill.write_mill_config_file = MagicMock()
+            mill.read_working_volume = MagicMock()
+            mill.clear_buffers = MagicMock()
+            mill._enforce_wpos_mode = MagicMock()
+            mill.set_feed_rate = MagicMock()
+            mill.current_coordinates = MagicMock(side_effect=LocationNotFound())
+            mill.read = MagicMock(return_value="<Idle|MPos:0,0,0|FS:0,0>")
+
+            with self.assertRaises(MillConnectionError):
+                mill.connect_to_mill(port='/dev/test')
 
     @patch('gantry.gantry_driver.driver.serial.Serial')
     @patch('gantry.gantry_driver.driver.set_up_mill_logger')


### PR DESCRIPTION
## Summary
- fail the mill connection early if GRBL does not report a usable work position after WPos mode is enforced
- surface the issue as a connection failure before any protocol motion starts
- cover the new guard with focused driver tests for both the success and failure paths

## Testing
- python -m pytest -q tests/gantry/driver/test_gantry_driver.py
- python -m pytest -q tests/gantry/test_gantry.py