### PR TITLE
Allow offset sign-independent plate calibration

### DIFF
--- a/configs/deck/asmi_deck.yaml
+++ b/configs/deck/asmi_deck.yaml
@@ -27,5 +27,5 @@ labware:
         x: 338
         y: 42.0
         z: 30.0
-    x_offset_mm: -9.0
+    x_offset_mm: 9.0
     y_offset_mm: 9.0

--- a/configs/deck/filmetrics_deck.yaml
+++ b/configs/deck/filmetrics_deck.yaml
@@ -24,5 +24,5 @@ labware:
         x: 270.0
         y: 131.0
         z: 70.0
-    x_offset_mm: -9.0
-    y_offset_mm: -9.0
+    x_offset_mm: 9.0
+    y_offset_mm: 9.0

--- a/src/deck/labware/definitions/sbs_96_wellplate/README.md
+++ b/src/deck/labware/definitions/sbs_96_wellplate/README.md
@@ -37,8 +37,8 @@ labware:
     calibration:
       a1: { x: -17.88, y: -42.23, z: -20.0 }
       a2: { x: -17.88, y: -51.23, z: -20.0 }
-    x_offset_mm: -9.0   # override signs if your deck orientation differs
-    y_offset_mm: -9.0
+    x_offset_mm: 9.0    # positive spacing magnitude; A1/A2 determine direction
+    y_offset_mm: 9.0
 ```
 
 Vendor-specific variants (e.g. Corning 360 µL round-bottom, deep-well

--- a/src/deck/loader.py
+++ b/src/deck/loader.py
@@ -257,8 +257,8 @@ def _resolve_plate_orientation(entry: Any) -> _PlateOrientation:
     Returns a ``_PlateOrientation`` whose deltas are used to compute each
     well position relative to A1 in ``_derive_wells_from_calibration``.
 
-    Raises ``ValueError`` when the A2 calibration step does not match
-    the declared offset or the points are not axis-aligned.
+    Raises ``ValueError`` when the A2 calibration step magnitude does not
+    match the declared offset magnitude or the points are not axis-aligned.
     """
     a1 = entry.a1_point
     a2 = entry.calibration.a2
@@ -268,26 +268,28 @@ def _resolve_plate_orientation(entry: Any) -> _PlateOrientation:
 
     if same_y:
         col_step = a2.x - a1.x
-        if abs(col_step - entry.x_offset_mm) > 1e-9:
+        if abs(abs(col_step) - entry.x_offset_mm) > 1e-9:
             raise ValueError(
                 "Calibration A2 must match one adjacent column step from A1 "
-                "(delta x must equal x_offset_mm)."
+                "(delta x magnitude must equal x_offset_mm magnitude)."
             )
+        row_step = -entry.y_offset_mm if col_step > 0 else entry.y_offset_mm
         return _PlateOrientation(
             col_delta_x=col_step, col_delta_y=0.0,
-            row_delta_x=0.0, row_delta_y=entry.y_offset_mm,
+            row_delta_x=0.0, row_delta_y=row_step,
         )
 
     if same_x:
         col_step = a2.y - a1.y
-        if abs(col_step - entry.y_offset_mm) > 1e-9:
+        if abs(abs(col_step) - entry.y_offset_mm) > 1e-9:
             raise ValueError(
                 "Calibration A2 must match one adjacent column step from A1 "
-                "(delta y must equal y_offset_mm)."
+                "(delta y magnitude must equal y_offset_mm magnitude)."
             )
+        row_step = entry.x_offset_mm if col_step > 0 else -entry.x_offset_mm
         return _PlateOrientation(
             col_delta_x=0.0, col_delta_y=col_step,
-            row_delta_x=entry.x_offset_mm, row_delta_y=0.0,
+            row_delta_x=row_step, row_delta_y=0.0,
         )
 
     raise ValueError("Calibration must be axis-aligned (same x or same y).")

--- a/src/deck/yaml_schema.py
+++ b/src/deck/yaml_schema.py
@@ -39,8 +39,8 @@ class WellPlateYamlEntry(BaseModel):
     # Backward compatibility: top-level A1 is accepted but deprecated.
     a1: Optional[_YamlPoint3D] = None
     calibration: _YamlCalibrationPoints
-    x_offset_mm: float
-    y_offset_mm: float
+    x_offset_mm: float = Field(..., gt=0)
+    y_offset_mm: float = Field(..., gt=0)
     # Volume — optional metadata.
     capacity_ul: Optional[float] = None
     working_volume_ul: Optional[float] = None
@@ -71,8 +71,6 @@ class WellPlateYamlEntry(BaseModel):
         if (self.capacity_ul is not None and self.working_volume_ul is not None
                 and self.working_volume_ul > self.capacity_ul):
             raise ValueError("working_volume_ul must be <= capacity_ul.")
-        if self.x_offset_mm == 0 or self.y_offset_mm == 0:
-            raise ValueError("x_offset_mm and y_offset_mm must be non-zero.")
         return self
 
 
@@ -137,8 +135,8 @@ class NestedWellPlateYamlEntry(BaseModel):
     width_mm: Optional[float] = None
     height_mm: Optional[float] = None
     calibration: _YamlCalibrationPoints
-    x_offset_mm: float
-    y_offset_mm: float
+    x_offset_mm: float = Field(..., gt=0)
+    y_offset_mm: float = Field(..., gt=0)
     capacity_ul: Optional[float] = None
     working_volume_ul: Optional[float] = None
 
@@ -163,8 +161,6 @@ class NestedWellPlateYamlEntry(BaseModel):
             raise ValueError(
                 "Calibration A2 must be axis-aligned with A1 (same x or same y); diagonal orientation is invalid."
             )
-        if self.x_offset_mm == 0 or self.y_offset_mm == 0:
-            raise ValueError("x_offset_mm and y_offset_mm must be non-zero.")
         if self.capacity_ul is not None and self.capacity_ul <= 0:
             raise ValueError("capacity_ul must be positive when specified.")
         if self.working_volume_ul is not None and self.working_volume_ul <= 0:
@@ -227,8 +223,8 @@ class TipRackYamlEntry(_BaseHolderYamlEntry):
     z_pickup: float = Field(..., gt=0)
     z_drop: Optional[float] = Field(default=None, gt=0)
     calibration: _YamlCalibrationPoints
-    x_offset_mm: float
-    y_offset_mm: float
+    x_offset_mm: float = Field(..., gt=0)
+    y_offset_mm: float = Field(..., gt=0)
     tip_present: Dict[str, bool] = Field(default_factory=dict)
     # Derived from the A1 tip if omitted.
     location: Optional[_YamlPoint3D] = None  # type: ignore[assignment]
@@ -253,8 +249,6 @@ class TipRackYamlEntry(_BaseHolderYamlEntry):
                 "Calibration A2 must be axis-aligned with A1 (same x or same y); "
                 "diagonal orientation is invalid."
             )
-        if self.x_offset_mm == 0 or self.y_offset_mm == 0:
-            raise ValueError("x_offset_mm and y_offset_mm must be non-zero.")
         return self
 
 

--- a/tests/test_deck_loader.py
+++ b/tests/test_deck_loader.py
@@ -41,7 +41,7 @@ labware:
         y: -10.0
         z: -15.0
     x_offset_mm: 9.0
-    y_offset_mm: -9.0
+    y_offset_mm: 9.0
     capacity_ul: 200.0
     working_volume_ul: 150.0
   vial_1:
@@ -245,7 +245,7 @@ labware:
     calibration:
       a2: { x: 10.0, y: 0.0, z: -5.0 }
     x_offset_mm: 10.0
-    y_offset_mm: -8.0
+    y_offset_mm: 8.0
     capacity_ul: 100.0
     working_volume_ul: 80.0
 """
@@ -266,7 +266,7 @@ labware:
 
 
 def test_calibration_horizontal_decreasing_columns():
-    """A2.x < A1.x, A2.y == A1.y: columns along -X."""
+    """A2.x < A1.x, A2.y == A1.y: A2 determines columns along -X."""
     yaml = """
 labware:
   p:
@@ -281,8 +281,43 @@ labware:
     a1: { x: 10.0, y: 0.0, z: -5.0 }
     calibration:
       a2: { x: 0.0, y: 0.0, z: -5.0 }
-    x_offset_mm: -10.0
-    y_offset_mm: -8.0
+    x_offset_mm: 10.0
+    y_offset_mm: 8.0
+    capacity_ul: 100.0
+    working_volume_ul: 80.0
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        f.write(yaml)
+        path = f.name
+    try:
+        result = load_deck_from_yaml(path)
+        plate = result["p"]
+        assert plate.get_well_center("A1").x == pytest.approx(10.0)
+        assert plate.get_well_center("A2").x == pytest.approx(0.0)
+        assert plate.get_well_center("A2").y == pytest.approx(0.0)
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+@pytest.mark.parametrize("x_offset_literal", ["+10.0", "10.0"])
+def test_calibration_column_sign_comes_from_a1_a2_not_x_offset_sign(x_offset_literal):
+    """Positive and unsigned X offsets allow A1/A2 to set column sign."""
+    yaml = f"""
+labware:
+  p:
+    type: well_plate
+    name: small
+    model_name: small
+    rows: 2
+    columns: 2
+    length_mm: 20.0
+    width_mm: 20.0
+    height_mm: 10.0
+    a1: {{ x: 10.0, y: 0.0, z: -5.0 }}
+    calibration:
+      a2: {{ x: 0.0, y: 0.0, z: -5.0 }}
+    x_offset_mm: {x_offset_literal}
+    y_offset_mm: 8.0
     capacity_ul: 100.0
     working_volume_ul: 80.0
 """
@@ -353,7 +388,7 @@ labware:
     calibration:
       a2: { x: 0.0, y: 0.0, z: -5.0 }
     x_offset_mm: 10.0
-    y_offset_mm: -8.0
+    y_offset_mm: 8.0
     capacity_ul: 100.0
     working_volume_ul: 80.0
 """
@@ -366,6 +401,41 @@ labware:
         assert plate.get_well_center("A1").y == pytest.approx(8.0)
         assert plate.get_well_center("A2").y == pytest.approx(0.0)
         assert plate.get_well_center("A2").x == pytest.approx(0.0)
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+@pytest.mark.parametrize("y_offset_literal", ["+8.0", "8.0"])
+def test_calibration_column_sign_comes_from_a1_a2_not_y_offset_sign(y_offset_literal):
+    """Positive and unsigned Y offsets allow A1/A2 to set column sign."""
+    yaml = f"""
+labware:
+  p:
+    type: well_plate
+    name: small
+    model_name: small
+    rows: 2
+    columns: 2
+    length_mm: 20.0
+    width_mm: 20.0
+    height_mm: 10.0
+    a1: {{ x: 0.0, y: 8.0, z: -5.0 }}
+    calibration:
+      a2: {{ x: 0.0, y: 0.0, z: -5.0 }}
+    x_offset_mm: 10.0
+    y_offset_mm: {y_offset_literal}
+    capacity_ul: 100.0
+    working_volume_ul: 80.0
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        f.write(yaml)
+        path = f.name
+    try:
+        result = load_deck_from_yaml(path)
+        plate = result["p"]
+        assert plate.get_well_center("A1").y == pytest.approx(8.0)
+        assert plate.get_well_center("A2").x == pytest.approx(0.0)
+        assert plate.get_well_center("A2").y == pytest.approx(0.0)
     finally:
         Path(path).unlink(missing_ok=True)
 
@@ -387,7 +457,7 @@ labware:
     calibration:
       a2: { x: 10.0, y: 5.0, z: -5.0 }
     x_offset_mm: 10.0
-    y_offset_mm: -8.0
+    y_offset_mm: 8.0
     capacity_ul: 100.0
     working_volume_ul: 80.0
 """
@@ -418,7 +488,7 @@ labware:
     calibration:
       a2: { x: 10.0, y: 5.0, z: -5.0 }
     x_offset_mm: 10.0
-    y_offset_mm: -8.0
+    y_offset_mm: 8.0
     capacity_ul: 100.0
     working_volume_ul: 80.0
 """
@@ -465,7 +535,7 @@ def test_safe_loader_missing_file_has_clean_message():
 
 
 def test_zero_offsets_fail_schema_validation():
-    """x/y offsets must be non-zero in well plate schema."""
+    """x/y offsets must be positive in well plate schema."""
     yaml = """
 labware:
   p:
@@ -481,7 +551,7 @@ labware:
       a1: { x: 0.0, y: 0.0, z: -15.0 }
       a2: { x: 9.0, y: 0.0, z: -15.0 }
     x_offset_mm: 0.0
-    y_offset_mm: -9.0
+    y_offset_mm: 9.0
     capacity_ul: 200.0
     working_volume_ul: 150.0
 """
@@ -490,6 +560,41 @@ labware:
         path = f.name
     try:
         with pytest.raises(ValidationError):
+            load_deck_from_yaml(path)
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+@pytest.mark.parametrize(
+    ("x_offset", "y_offset"),
+    [(-9.0, 9.0), (9.0, -9.0)],
+)
+def test_negative_offsets_fail_schema_validation(x_offset, y_offset):
+    """Offset fields are spacing magnitudes and must not be negative."""
+    yaml = f"""
+labware:
+  p:
+    type: well_plate
+    name: x
+    model_name: x
+    rows: 8
+    columns: 12
+    length_mm: 127.71
+    width_mm: 85.43
+    height_mm: 14.10
+    calibration:
+      a1: {{ x: 0.0, y: 0.0, z: -15.0 }}
+      a2: {{ x: 9.0, y: 0.0, z: -15.0 }}
+    x_offset_mm: {x_offset}
+    y_offset_mm: {y_offset}
+    capacity_ul: 200.0
+    working_volume_ul: 150.0
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        f.write(yaml)
+        path = f.name
+    try:
+        with pytest.raises(ValidationError, match="greater than 0"):
             load_deck_from_yaml(path)
     finally:
         Path(path).unlink(missing_ok=True)
@@ -512,7 +617,7 @@ labware:
     calibration:
       a2: { x: 0.0, y: 0.0, z: -5.0 }
     x_offset_mm: 10.0
-    y_offset_mm: -8.0
+    y_offset_mm: 8.0
     capacity_ul: 100.0
     working_volume_ul: 80.0
 """
@@ -555,7 +660,7 @@ labware:
     height_mm: 14.10
     a1: { x: 0.0, y: 0.0, z: -15.0 }
     x_offset_mm: 9.0
-    y_offset_mm: -9.0
+    y_offset_mm: 9.0
     capacity_ul: 200.0
     working_volume_ul: 150.0
 """
@@ -627,7 +732,7 @@ labware:
     calibration:
       a2: { x: 9.0, y: 0.0, z: -15.0 }
     x_offset_mm: 9.0
-    y_offset_mm: -9.0
+    y_offset_mm: 9.0
     capacity_ul: 200.0
     working_volume_ul: 150.0
     unknown_field: 1
@@ -661,7 +766,7 @@ labware:
     calibration:
       a2: { x: 9.0, y: 0.0, z: -15.0 }
     x_offset_mm: 9.0
-    y_offset_mm: -9.0
+    y_offset_mm: 9.0
     capacity_ul: 200.0
     working_volume_ul: 150.0
 """
@@ -693,7 +798,7 @@ labware:
     calibration:
       a2: { x: 9.0, y: 0.0, z: -15.0 }
     x_offset_mm: 9.0
-    y_offset_mm: -9.0
+    y_offset_mm: 9.0
     capacity_ul: 200.0
     working_volume_ul: 150.0
 """
@@ -726,7 +831,7 @@ labware:
     calibration:
       a2: { x: 9.0, y: 0.0, z: -15.0 }
     x_offset_mm: 9.0
-    y_offset_mm: -9.0
+    y_offset_mm: 9.0
     capacity_ul: 200.0
     working_volume_ul: 250.0
 """
@@ -757,7 +862,7 @@ labware:
     calibration:
       a2: { x: 9.0, y: 0.0, z: -15.0 }
     x_offset_mm: 9.0
-    y_offset_mm: -9.0
+    y_offset_mm: 9.0
     capacity_ul: 0.0
     working_volume_ul: 0.0
 """
@@ -787,7 +892,7 @@ labware:
     calibration:
       a2: { x: 19.0, y: 20.0, z: -5.0 }
     x_offset_mm: 9.0
-    y_offset_mm: -9.0
+    y_offset_mm: 9.0
 """
     with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
         f.write(yaml_str)
@@ -821,7 +926,7 @@ labware:
     calibration:
       a2: { x: 9.0, y: 0.0, z: 0.0 }
     x_offset_mm: 9.0
-    y_offset_mm: -9.0
+    y_offset_mm: 9.0
     capacity_ul: 200.0
 """
     with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
@@ -857,7 +962,7 @@ def test_empty_labware_dict_allowed():
 
 def _make_entry(
     a1_x=0.0, a1_y=0.0, a2_x=10.0, a2_y=0.0,
-    x_offset=10.0, y_offset=-8.0, z=-5.0,
+    x_offset=10.0, y_offset=8.0, z=-5.0,
 ) -> WellPlateYamlEntry:
     """Build a minimal WellPlateYamlEntry for orientation tests."""
     return WellPlateYamlEntry(
@@ -877,7 +982,7 @@ class TestResolvePlateOrientation:
 
     def test_horizontal_columns_along_x(self):
         entry = _make_entry(a1_x=0.0, a1_y=0.0, a2_x=10.0, a2_y=0.0,
-                            x_offset=10.0, y_offset=-8.0)
+                            x_offset=10.0, y_offset=8.0)
         orient = _resolve_plate_orientation(entry)
         assert orient == _PlateOrientation(
             col_delta_x=10.0, col_delta_y=0.0,
@@ -893,30 +998,45 @@ class TestResolvePlateOrientation:
             row_delta_x=10.0, row_delta_y=0.0,
         )
 
-    def test_negative_x_column_step(self):
+    def test_negative_offsets_fail_schema_validation(self):
+        with pytest.raises(ValidationError, match="greater than 0"):
+            _make_entry(a1_x=10.0, a1_y=0.0, a2_x=0.0, a2_y=0.0,
+                        x_offset=-10.0, y_offset=8.0)
+        with pytest.raises(ValidationError, match="greater than 0"):
+            _make_entry(a1_x=10.0, a1_y=0.0, a2_x=0.0, a2_y=0.0,
+                        x_offset=10.0, y_offset=-8.0)
+
+    def test_negative_x_column_step_allows_positive_offset_magnitude(self):
         entry = _make_entry(a1_x=10.0, a1_y=0.0, a2_x=0.0, a2_y=0.0,
-                            x_offset=-10.0, y_offset=-8.0)
+                            x_offset=10.0, y_offset=8.0)
         orient = _resolve_plate_orientation(entry)
         assert orient.col_delta_x == pytest.approx(-10.0)
         assert orient.col_delta_y == pytest.approx(0.0)
 
     def test_negative_y_column_step(self):
         entry = _make_entry(a1_x=0.0, a1_y=8.0, a2_x=0.0, a2_y=0.0,
-                            x_offset=10.0, y_offset=-8.0)
+                            x_offset=10.0, y_offset=8.0)
+        orient = _resolve_plate_orientation(entry)
+        assert orient.col_delta_y == pytest.approx(-8.0)
+        assert orient.col_delta_x == pytest.approx(0.0)
+
+    def test_negative_y_column_step_allows_positive_offset_magnitude(self):
+        entry = _make_entry(a1_x=0.0, a1_y=8.0, a2_x=0.0, a2_y=0.0,
+                            x_offset=10.0, y_offset=8.0)
         orient = _resolve_plate_orientation(entry)
         assert orient.col_delta_y == pytest.approx(-8.0)
         assert orient.col_delta_x == pytest.approx(0.0)
 
     def test_mismatched_x_offset_raises(self):
         entry = _make_entry(a1_x=0.0, a1_y=0.0, a2_x=10.0, a2_y=0.0,
-                            x_offset=5.0, y_offset=-8.0)
-        with pytest.raises(ValueError, match="delta x must equal x_offset_mm"):
+                            x_offset=5.0, y_offset=8.0)
+        with pytest.raises(ValueError, match="delta x magnitude must equal x_offset_mm magnitude"):
             _resolve_plate_orientation(entry)
 
     def test_mismatched_y_offset_raises(self):
         entry = _make_entry(a1_x=0.0, a1_y=0.0, a2_x=0.0, a2_y=8.0,
                             x_offset=10.0, y_offset=4.0)
-        with pytest.raises(ValueError, match="delta y must equal y_offset_mm"):
+        with pytest.raises(ValueError, match="delta y magnitude must equal y_offset_mm magnitude"):
             _resolve_plate_orientation(entry)
 
     def test_returns_frozen_dataclass(self):

--- a/tests/test_holder_labware.py
+++ b/tests/test_holder_labware.py
@@ -243,7 +243,7 @@ labware:
         assert isinstance(holder.contained_labware["plate"], WellPlate)
         assert deck.resolve("plate_holder.plate") == Coordinate3D(x=221.75, y=78.5, z=188.0)
         assert deck.resolve("plate_holder.plate.A1") == Coordinate3D(x=221.75, y=78.5, z=188.0)
-        assert deck.resolve("plate_holder.plate.B2") == Coordinate3D(x=230.75, y=87.5, z=188.0)
+        assert deck.resolve("plate_holder.plate.B2") == Coordinate3D(x=230.75, y=69.5, z=188.0)
     finally:
         Path(path).unlink(missing_ok=True)
 


### PR DESCRIPTION
## Summary
- Require calibration offsets to be positive spacing magnitudes in YAML/schema validation
- Use A1→A2 to determine column direction, then derive the perpendicular row direction from that orientation
- Update candidate deck configs/docs to use positive offsets only
- Add focused tests for positive/unsigned offsets, negative-offset validation failures, and sign-independent orientation

Fixes #69

## Verification
- Fresh venv editable install with dev extras succeeded: `python -m pip install -e '.[dev]'`
- `python -m pytest tests/test_deck_loader.py tests/test_holder_labware.py -q` → `62 passed in 0.54s`
- `python -m pytest -q` → `1010 passed, 15 skipped in 10.94s`
- `git diff --check` passed
- Standalone setup/schema validation script passed for changed candidate configs and active protocols:
  - `python setup/validate_setup.py configs/gantry/cub_xl_asmi.yaml configs/deck/asmi_deck.yaml configs/protocol/asmi_move_a1.yaml` → `RESULT: PASS`
  - `python setup/validate_setup.py configs/gantry/cub_xl_asmi.yaml configs/deck/asmi_deck.yaml configs/protocol/asmi_indentation.yaml` → `RESULT: PASS`
  - `python setup/validate_setup.py configs/gantry/cub_filmetrics.yaml configs/deck/filmetrics_deck.yaml configs/protocol/filmetrics_scan.yaml` → `RESULT: PASS`
  - `python setup/validate_setup.py configs/gantry/cub_xl_sterling.yaml configs/deck/sterling_deck.yaml configs/protocol/sterling_park.yaml` → `RESULT: PASS`
  - `python setup/validate_setup.py configs/gantry/cub_xl_sterling.yaml configs/deck/sterling_deck.yaml configs/protocol/sterling_vial_scan.yaml` → `RESULT: PASS`
