### PR TITLE
Add retrieval-led agent context index

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,13 @@
 
 This repository contains code to control a CNC router (mill) using a Python-based driver that communicates over serial (GRBL).
 
+
+## Retrieval-Led Agent Index
+
+Before coding, prefer repo source/docs over model memory. Use `docs/agent-index.md` as the compact routing map for where to look before touching hardware, deck YAML/schema, protocol setup, instruments, validation, or docs.
+
+Key rule: do not rely on an optional skill/tool invocation for CubOS semantics. Read the relevant source/docs from the index, then implement and verify against real tests/config validation.
+
 ## Hardware Development Rule
 
 This is software for a hardware repository. Any development work can affect real motion, instruments, samples, or connected controllers.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,3 +8,5 @@ Always write clean code, using the principles from the book "Clean Code" by Robe
 When you finish a task, make sure to update your progress in the progress/ directory.
 If the task makes a fundamental change (i.e. you add a new command line argument, you add a brand new feature) make sure to add it to AGENTS.md and README.md such that another agent or human can understand for context easily if changes need to be made.
 Always create a plan that I will review before executing when in planning mode.
+
+Agent retrieval rule: before coding, read `AGENTS.md` and `docs/agent-index.md`, then retrieve the specific source/docs named there for the subsystem you are touching. Prefer repo-grounded reasoning over model memory for CubOS semantics, especially hardware motion, coordinate frames, YAML schema, validation, and protocol setup.

--- a/docs/agent-index.md
+++ b/docs/agent-index.md
@@ -1,0 +1,80 @@
+# CubOS Agent Index
+
+Use this as the first retrieval map for coding agents. Prefer repo source/docs over model memory, especially for hardware, YAML schema, protocol, and coordinate semantics.
+
+## Start here
+
+- Always read `AGENTS.md` and `CLAUDE.md` before coding.
+- For hardware-facing changes, include hardware impact, offline validation, and required physical validation in the PR.
+- For long or risky work, maintain a temporary checkpoint under `progress/` and delete it or promote durable notes before handoff.
+
+## Coordinate and motion semantics
+
+Read these before changing gantry motion, coordinates, bounds, homing, scan movement, or protocol movement:
+
+- `AGENTS.md` — hardware rules and current coordinate convention.
+- `src/gantry/gantry.py`, `src/gantry/gantry_config.py`, `src/gantry/origin.py` — gantry frame, working volume, deck-origin calibration.
+- `src/board/board.py`, `src/board/loader.py` — instrument offsets and labware movement.
+- `src/validation/bounds.py`, `src/validation/protocol_semantics.py` — offline safety checks.
+- `tests/protocol_engine/test_deck_origin_candidate_configs.py` — real config/protocol expectations.
+
+Retrieval rule: do not infer sign flips from older code or model memory. Confirm current deck-frame convention in source and tests.
+
+## Deck YAML, labware, and calibration
+
+Read these before changing deck configs, labware schemas, well position math, or validation messages:
+
+- `src/deck/yaml_schema.py` — strict Pydantic YAML schema.
+- `src/deck/loader.py` — load-name expansion, calibration, derived wells, nested labware.
+- `src/deck/labware/` — runtime labware models.
+- `src/deck/labware/definitions/` — reusable labware definitions.
+- `configs/deck/` — real candidate deck YAMLs.
+- `tests/test_deck_loader.py`, `tests/test_holder_labware.py`, `tests/test_panda_deck_yaml.py` — focused behavior gates.
+
+Validation rule: after schema/config changes, run focused tests, full tests when practical, and `setup/validate_setup.py` for affected real gantry/deck/protocol triples.
+
+## Protocol engine and setup validation
+
+Read these before changing protocol YAML, protocol command args, setup loading, or semantic validation:
+
+- `src/protocol_engine/yaml_schema.py`, `src/protocol_engine/loader.py`, `src/protocol_engine/setup.py`.
+- `src/protocol_engine/commands/` for command behavior.
+- `setup/validate_setup.py` for the end-to-end offline validation path.
+- `configs/protocol/` for real protocol examples.
+- `tests/protocol_engine/` for expected behavior.
+
+Validation command pattern:
+
+```bash
+python setup/validate_setup.py <gantry.yaml> <deck.yaml> <protocol.yaml>
+```
+
+## Instruments
+
+Read these before changing instrument drivers, mock behavior, or measurement persistence:
+
+- `src/instruments/<instrument>/driver.py`, `mock.py`, `models.py`, `exceptions.py`.
+- `src/instruments/registry.yaml`, `src/instruments/yaml_schema.py`.
+- `src/protocol_engine/measurements.py`, `data/data_store.py` for persisted measurements.
+- Relevant tests under `tests/instruments/`, `tests/protocol_engine/`, and `tests/data/`.
+
+Hardware rule: if a change can touch a physical instrument, say what hardware validation remains.
+
+## Config and docs updates
+
+- If validation semantics change, search real configs/docs/examples for now-invalid patterns.
+- If adding a fundamental feature, CLI argument, workflow, or semantic contract, update `AGENTS.md`, `README.md`, and relevant docs.
+- Keep progress notes under `progress/` for each coding task per `CLAUDE.md`.
+
+## Common verification gates
+
+Use the smallest meaningful gate first, then broaden as risk requires:
+
+```bash
+python -m pytest tests/test_deck_loader.py tests/test_holder_labware.py -q
+python -m pytest tests/protocol_engine -q
+python -m pytest -q
+python setup/validate_setup.py configs/gantry/cub_xl_asmi.yaml configs/deck/asmi_deck.yaml configs/protocol/asmi_indentation.yaml
+```
+
+Report exact commands and observed results in the PR body.

--- a/progress/2026-04-28-agent-index.md
+++ b/progress/2026-04-28-agent-index.md
@@ -1,0 +1,19 @@
+# 2026-04-28 Agent index docs
+
+## Work done
+
+- Added `docs/agent-index.md` as a compact retrieval map for CubOS coding agents.
+- Added a short `AGENTS.md` section pointing agents to the retrieval index before coding.
+- Added a `CLAUDE.md` retrieval rule so Claude-style agents read the same index.
+
+## Why
+
+The Vercel AGENTS.md eval writeup suggests always-loaded project context and compact doc indexes are more reliable than optional skill invocation for general framework/project knowledge. CubOS has hardware and validation semantics that should be retrieved from source/docs rather than guessed from model memory.
+
+## Verification
+
+Docs-only change. Verified by direct inspection and repository grep for the new routing section.
+
+## Hardware impact
+
+No hardware behavior changed. No physical hardware validation required.


### PR DESCRIPTION
## Summary
- Add `docs/agent-index.md` as a compact retrieval map for CubOS coding agents
- Point `AGENTS.md` and `CLAUDE.md` at the index so repo-grounded lookup happens before coding
- Add a dated `progress/` note documenting the rationale and hardware impact

## Context
This follows the Vercel AGENTS.md evaluation takeaway: broad project/framework knowledge is more reliable when available as always-loaded project context plus a compact retrieval index, rather than relying on optional skill invocation.

## Verification
- `grep -R "Retrieval-Led Agent Index\|Agent retrieval rule\|CubOS Agent Index" -n AGENTS.md CLAUDE.md docs/agent-index.md progress/2026-04-28-agent-index.md` found the new routing hooks and index title
- `git diff --check` passed

## Hardware impact
- Hardware touched or potentially affected: none; documentation-only change
- Offline validation performed: direct doc inspection and whitespace check
- Required hardware validation: none
