### PR TITLE
Reject invalid gantry motion before G-code formatting

### DIFF
--- a/progress/2026-04-30-gantry-driver-safety-pass.md
+++ b/progress/2026-04-30-gantry-driver-safety-pass.md
@@ -1,0 +1,31 @@
+# 2026-04-30 Gantry Driver Safety Pass
+
+## Scope
+- Branch: `ben/gantry-driver-safety-pass-20260430`
+- Goal: first small hardening PR for low-level gantry/G-code driver predictability.
+- Initial target: reject non-finite motion values before the low-level driver formats G-code.
+
+## Current Plan
+1. Add a focused failing driver test for non-finite target and travel coordinates. Done.
+2. Add the smallest validation layer at the `Mill` movement boundary. Done.
+3. Run focused gantry driver tests, then broader feasible tests. Partially blocked by missing local dependencies; syntax and direct driver smoke checks run.
+4. Commit, push, open a PR against `staging`, and include hardware impact plus verification. Pending.
+
+## Work Completed
+- Added a regression test proving `Mill.move_to_position()` rejects NaN/Inf target coordinates and NaN travel Z without emitting G-code.
+- Re-enabled low-level target coordinate validation in `src/gantry/gantry_driver/driver.py`.
+- Added finite-number validation before the no-op movement check so invalid travel Z cannot be hidden by an otherwise unchanged target.
+- Added the same guard in movement command generation as a final boundary before raw G-code strings are formatted.
+
+## Validation
+- `python3 -m py_compile src/gantry/gantry_driver/driver.py tests/gantry/driver/test_gantry_driver.py` -> passed.
+- Direct import/smoke harness with stubbed serial module -> passed (`driver validation smoke passed`).
+- `python3 -m pytest tests/gantry/driver/test_gantry_driver.py -q` -> blocked: `/usr/bin/python3: No module named pytest`.
+- `python3 -m pytest -q` -> blocked: `/usr/bin/python3: No module named pytest`.
+- `PYTHONPATH=src python3 tests/gantry/driver/test_gantry_driver.py` -> blocked: `ModuleNotFoundError: No module named 'pydantic'`.
+- `.venv/bin/python -m pip install -e '.[dev]'` -> blocked by restricted network/DNS while resolving build dependency `setuptools`.
+
+## Hardware Impact
+- Potentially affected hardware: CNC gantry XYZ motion only, through low-level G-code emission.
+- Current validation: offline/mock tests only.
+- Required physical validation before trust: dry-run a bounded gantry move sequence on the target controller and confirm valid finite moves still execute as expected.

--- a/src/gantry/gantry_driver/driver.py
+++ b/src/gantry/gantry_driver/driver.py
@@ -12,6 +12,7 @@ of the mill.
 # pylint: disable=line-too-long
 
 # standard libraries
+import math
 import os
 import re
 import time
@@ -937,6 +938,9 @@ class Mill:
             if not coordinates
             else coordinates
         )
+        self._validate_target_coordinates(goto)
+        if travel_z is not None:
+            self._validate_finite_coordinate(travel_z, "travel Z")
         offsets = self.instrument_manager.get_offset(instrument)
         current_coordinates = self.current_coordinates()
 
@@ -1015,8 +1019,18 @@ class Mill:
         )
 
     def _validate_target_coordinates(self, target_coordinates: Coordinates):
-        # Validation disabled by request
-        pass
+        self._validate_finite_coordinate(target_coordinates.x, "target X")
+        self._validate_finite_coordinate(target_coordinates.y, "target Y")
+        self._validate_finite_coordinate(target_coordinates.z, "target Z")
+
+    @staticmethod
+    def _validate_finite_coordinate(value: float, label: str) -> None:
+        try:
+            numeric_value = float(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"{label} must be finite; got {value!r}.") from exc
+        if not math.isfinite(numeric_value):
+            raise ValueError(f"{label} must be finite; got {value!r}.")
 
     def _generate_movement_commands(
         self,
@@ -1032,6 +1046,7 @@ class Mill:
         obstacles the caller didn't plan for.
         """
         f = f" F{DEFAULT_FEED_RATE}"
+        self._validate_target_coordinates(target_coordinates)
         commands = []
         if target_coordinates.x != current_coordinates.x:
             commands.append(f"G01 X{target_coordinates.x}{f}")
@@ -1056,6 +1071,8 @@ class Mill:
         separate G-codes — no diagonal.
         """
         f = f" F{DEFAULT_FEED_RATE}"
+        self._validate_target_coordinates(target_coordinates)
+        self._validate_finite_coordinate(travel_z, "travel Z")
         commands = []
         if current_coordinates.z != travel_z:
             commands.append(f"G01 Z{travel_z}{f}")

--- a/tests/gantry/driver/test_gantry_driver.py
+++ b/tests/gantry/driver/test_gantry_driver.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 import sys
 from pathlib import Path
+import math
 
 # Add project root to path
 project_root = Path(__file__).parent.parent
@@ -182,6 +183,38 @@ class TestCNCDriverLogic(unittest.TestCase):
             "G01 Y-60.0 F2000",
             "G01 Z-90.0 F2000",
         ])
+
+    @patch('gantry.gantry_driver.driver.serial.Serial')
+    @patch('gantry.gantry_driver.driver.set_up_mill_logger')
+    @patch('gantry.gantry_driver.driver.set_up_command_logger')
+    def test_move_to_position_rejects_non_finite_motion_inputs(
+        self, mock_cmd_logger, mock_mill_logger, mock_serial,
+    ):
+        """The low-level driver must not format NaN/Inf into G-code."""
+        cases = [
+            {"x_coordinate": math.nan, "y_coordinate": 0.0, "z_coordinate": 0.0},
+            {"x_coordinate": 0.0, "y_coordinate": math.inf, "z_coordinate": 0.0},
+            {"x_coordinate": 0.0, "y_coordinate": 0.0, "z_coordinate": -math.inf},
+            {
+                "x_coordinate": 0.0,
+                "y_coordinate": 0.0,
+                "z_coordinate": 0.0,
+                "travel_z": math.nan,
+            },
+        ]
+
+        for kwargs in cases:
+            with self.subTest(kwargs=kwargs):
+                mill = Mill()
+                mill.current_coordinates = MagicMock(
+                    return_value=Coordinates(0.0, 0.0, 0.0),
+                )
+                mill.execute_command = MagicMock()
+
+                with self.assertRaisesRegex(ValueError, "finite"):
+                    mill.move_to_position(**kwargs)
+
+                mill.execute_command.assert_not_called()
 
     @patch('gantry.gantry_driver.driver.time.sleep')
     @patch('gantry.gantry_driver.driver.time.time', side_effect=[0.0, 2.0])


### PR DESCRIPTION
## Summary
- Re-enable low-level `Mill` target coordinate validation before motion planning.
- Reject NaN/Inf target coordinates and `travel_z` before raw G-code is formatted or emitted.
- Add a focused regression test that proves invalid motion inputs do not call `execute_command`.
- Add a short progress checkpoint for this first gantry-driver hardening pass.

## Verification
- `python3 -m py_compile src/gantry/gantry_driver/driver.py tests/gantry/driver/test_gantry_driver.py` -> passed
- Direct import/smoke harness with stubbed serial module -> passed (`driver validation smoke passed`)
- `git diff --check` -> passed
- `python3 -m pytest tests/gantry/driver/test_gantry_driver.py -q` -> blocked locally: `/usr/bin/python3: No module named pytest`
- `python3 -m pytest -q` -> blocked locally: `/usr/bin/python3: No module named pytest`
- `PYTHONPATH=src python3 tests/gantry/driver/test_gantry_driver.py` -> blocked locally: `ModuleNotFoundError: No module named 'pydantic'`
- `.venv/bin/python -m pip install -e '.[dev]'` -> blocked locally by restricted network/DNS while resolving build dependency `setuptools`

## Hardware impact
- Hardware touched or potentially affected: CNC gantry XYZ motion through low-level G-code emission.
- Offline validation performed: syntax compile, diff whitespace check, and smoke harness with serial stub.
- Physical hardware validation still pending: dry-run a bounded gantry move sequence on the target controller and confirm normal finite moves still execute as expected.

## Notes
This is intentionally small: it adds a driver-boundary safety invariant rather than rewriting the movement stack. Follow-up PRs in the 7-day hardening stream can keep tightening abstraction boundaries and command-generation invariants.
