### PR TITLE
Harden gantry status line parsing

### DIFF
--- a/progress/2026-05-04-gantry-driver-status-requery.md
+++ b/progress/2026-05-04-gantry-driver-status-requery.md
@@ -1,0 +1,35 @@
+# 2026-05-04 Gantry driver status re-query hardening
+
+## Scope
+
+Active PR: https://github.com/Ursa-Laboratories/CubOS/pull/109
+Branch: `ben/gantry-driver-position-parse-20260501`
+Base: `upstream/staging` at `68384188912e0fe6d50345a026d5ed3855bf0e69`
+
+Small follow-up hardening: make `Mill.current_coordinates()` actively re-query GRBL with `?` after an incomplete/noisy status fragment, instead of only draining whatever serial bytes happen to remain buffered.
+
+## Hardware impact
+
+Potentially affects GRBL gantry/CNC status polling before reporting coordinates. This does not change move command geometry or feed rates, but it changes retry behavior when the serial status read is incomplete/noisy.
+
+## Validation
+
+- Added regression coverage that a truncated `<Idle|WPos:...` fragment causes `current_coordinates()` to issue another `?` query before accepting the next complete status.
+- Offline/mock validation only; no physical gantry tested.
+
+Exact local checks run:
+
+```text
+/tmp/cubos-gantry-venv/bin/python -m pytest tests/gantry/driver/test_wpos_enforcement.py tests/gantry/driver/test_gantry_driver.py -q
+=> 39 passed, 4 subtests passed in 1.17s
+
+/tmp/cubos-gantry-venv/bin/python -m py_compile src/gantry/gantry_driver/driver.py tests/gantry/driver/test_wpos_enforcement.py
+=> passed (no output)
+
+git diff --check
+=> passed (no output)
+```
+
+## Required hardware validation
+
+On a real GRBL gantry, confirm repeated `current_coordinates()` calls still return WPos reliably after normal serial chatter and during idle status polling.

--- a/src/gantry/gantry_driver/driver.py
+++ b/src/gantry/gantry_driver/driver.py
@@ -669,6 +669,17 @@ class Mill:
         msg = msg.decode(encoding="ascii")
         return msg
 
+    @staticmethod
+    def _extract_status_line(status: str) -> str:
+        """Return the first GRBL status line from a serial read chunk."""
+        if not status:
+            return ""
+        for line in status.splitlines():
+            line = line.strip()
+            if line.startswith("<"):
+                return line
+        return status.strip()
+
     def txrx(self, command: str) -> str:
         """Write a command to the mill and read the response."""
         self.write(command)
@@ -804,7 +815,7 @@ class Mill:
         """
         self.ser_mill.write(b"?")
         time.sleep(0.05)
-        status = self.read()
+        status = self._extract_status_line(self.read())
         attempts = 0
         while (not status or status[0] != "<") and attempts < 3:
             if "alarm" in status.lower() or "error" in status.lower():
@@ -813,7 +824,7 @@ class Mill:
                 raise StatusReturnError(f"Error in status: {status}")
             if "ok" in status.lower():
                 self.logger.debug("OK in status: %s", status)
-            status = self.read()
+            status = self._extract_status_line(self.read())
             attempts += 1
 
         self.last_status = status
@@ -875,10 +886,10 @@ class Mill:
                 time.sleep(0.2)
                 self.ser_mill.write(b"?")
                 time.sleep(0.2)
-                status = self.read()
+                status = self._extract_status_line(self.read())
                 retry_attempts = 0
                 while (not status or status[0] != "<") and retry_attempts < 3:
-                    status = self.read()
+                    status = self._extract_status_line(self.read())
                     retry_attempts += 1
 
         mill_center = Coordinates(x_coord, y_coord, z_coord)

--- a/src/gantry/gantry_driver/driver.py
+++ b/src/gantry/gantry_driver/driver.py
@@ -624,6 +624,8 @@ class Mill:
     def current_status(self) -> str:
         """Get the current status of the mill."""
         attempt_limit = 5
+        self.ser_mill.write(b"?")
+        time.sleep(0.05)
         status = self.read()
 
         while self._extract_status_line(status) in ["", "ok"] and attempt_limit > 0:

--- a/src/gantry/gantry_driver/driver.py
+++ b/src/gantry/gantry_driver/driver.py
@@ -626,11 +626,21 @@ class Mill:
         attempt_limit = 5
         status = self.read()
 
-        while status in ["", "ok"] and attempt_limit > 0:
+        while self._extract_status_line(status) in ["", "ok"] and attempt_limit > 0:
             self.ser_mill.write(b"?")
             time.sleep(0.05)
             status = self.read()
             attempt_limit -= 1
+
+        if re.search(r"\b(error|alarm)\b", status.lower()):
+            self.logger.error("Error in status: %s", status)
+            self.last_status = status
+            if self.interactive_mode:
+                print(f"Error in status: {status}")
+                return ""
+            raise StatusReturnError(f"Error in status: {status}")
+
+        status = self._extract_status_line(status)
 
         if not status:
             raw_lines = self.ser_mill.readlines()
@@ -641,8 +651,9 @@ class Mill:
                     print("Failed to get status from the mill")
                     return ""
                 raise StatusReturnError("Failed to get status from the mill")
-            # Find the first status line (<...>) or join all lines
-            status = next((l for l in lines if l.startswith("<")), "; ".join(lines))
+            status = self._extract_status_line("\n".join(lines))
+            if not status:
+                status = "; ".join(lines)
             if any(re.search(r"\b(error|alarm)\b", item.lower()) for item in lines):
                 self.logger.error("Error in status: %s", status)
                 self.last_status = status

--- a/src/gantry/gantry_driver/driver.py
+++ b/src/gantry/gantry_driver/driver.py
@@ -698,6 +698,13 @@ class Mill:
             return ""
         return status.strip()
 
+    def _raise_if_status_error(self, status: str) -> None:
+        """Raise if a raw GRBL read contains error/alarm chatter."""
+        if status and re.search(r"\b(error|alarm)\b", status.lower()):
+            self.logger.error("Error in status: %s", status)
+            self.last_status = status
+            raise StatusReturnError(f"Error in status: {status}")
+
     def txrx(self, command: str) -> str:
         """Write a command to the mill and read the response."""
         self.write(command)
@@ -833,18 +840,18 @@ class Mill:
         """
         self.ser_mill.write(b"?")
         time.sleep(0.05)
-        status = self._extract_status_line(self.read())
+        raw_status = self.read()
+        self._raise_if_status_error(raw_status)
+        status = self._extract_status_line(raw_status)
         attempts = 0
         while (not status or status[0] != "<") and attempts < 3:
-            if "alarm" in status.lower() or "error" in status.lower():
-                self.logger.error("Error in status: %s", status)
-                self.last_status = status
-                raise StatusReturnError(f"Error in status: {status}")
             if "ok" in status.lower():
                 self.logger.debug("OK in status: %s", status)
             self.ser_mill.write(b"?")
             time.sleep(0.05)
-            status = self._extract_status_line(self.read())
+            raw_status = self.read()
+            self._raise_if_status_error(raw_status)
+            status = self._extract_status_line(raw_status)
             attempts += 1
 
         self.last_status = status
@@ -906,12 +913,16 @@ class Mill:
                 time.sleep(0.2)
                 self.ser_mill.write(b"?")
                 time.sleep(0.2)
-                status = self._extract_status_line(self.read())
+                raw_status = self.read()
+                self._raise_if_status_error(raw_status)
+                status = self._extract_status_line(raw_status)
                 retry_attempts = 0
                 while (not status or status[0] != "<") and retry_attempts < 3:
                     self.ser_mill.write(b"?")
                     time.sleep(0.05)
-                    status = self._extract_status_line(self.read())
+                    raw_status = self.read()
+                    self._raise_if_status_error(raw_status)
+                    status = self._extract_status_line(raw_status)
                     retry_attempts += 1
 
         mill_center = Coordinates(x_coord, y_coord, z_coord)

--- a/src/gantry/gantry_driver/driver.py
+++ b/src/gantry/gantry_driver/driver.py
@@ -682,13 +682,18 @@ class Mill:
 
     @staticmethod
     def _extract_status_line(status: str) -> str:
-        """Return the first GRBL status line from a serial read chunk."""
+        """Return the first complete GRBL status line from a serial read chunk."""
         if not status:
             return ""
+        saw_status_fragment = False
         for line in status.splitlines():
             line = line.strip()
             if line.startswith("<"):
-                return line
+                saw_status_fragment = True
+                if line.endswith(">"):
+                    return line
+        if saw_status_fragment:
+            return ""
         return status.strip()
 
     def txrx(self, command: str) -> str:

--- a/src/gantry/gantry_driver/driver.py
+++ b/src/gantry/gantry_driver/driver.py
@@ -840,6 +840,8 @@ class Mill:
                 raise StatusReturnError(f"Error in status: {status}")
             if "ok" in status.lower():
                 self.logger.debug("OK in status: %s", status)
+            self.ser_mill.write(b"?")
+            time.sleep(0.05)
             status = self._extract_status_line(self.read())
             attempts += 1
 
@@ -905,6 +907,8 @@ class Mill:
                 status = self._extract_status_line(self.read())
                 retry_attempts = 0
                 while (not status or status[0] != "<") and retry_attempts < 3:
+                    self.ser_mill.write(b"?")
+                    time.sleep(0.05)
                     status = self._extract_status_line(self.read())
                     retry_attempts += 1
 

--- a/tests/gantry/driver/test_wpos_enforcement.py
+++ b/tests/gantry/driver/test_wpos_enforcement.py
@@ -129,6 +129,36 @@ class TestWposEnforcement(unittest.TestCase):
         with self.assertRaisesRegex(StatusReturnError, "ALARM:2"):
             mill.current_status()
 
+    def test_current_coordinates_raises_when_chatter_contains_alarm(self):
+        mill = self._make_mill()
+        mill.ser_mill.write = MagicMock()
+        mill.read = MagicMock(
+            return_value=(
+                "ok\nALARM:2\n"
+                "<Idle|WPos:10.000,20.000,5.000|Bf:15,127|FS:0,0>\n"
+            )
+        )
+
+        with self.assertRaisesRegex(StatusReturnError, "ALARM:2"):
+            mill.current_coordinates()
+        self.assertEqual(mill.last_status, mill.read.return_value)
+        mill.ser_mill.write.assert_called_once_with(b"?")
+
+    def test_current_coordinates_raises_when_retry_chatter_contains_error(self):
+        mill = self._make_mill()
+        mill.ser_mill.write = MagicMock()
+        mill.read = MagicMock(
+            side_effect=[
+                "<Idle|WPos:10.000,20.000,5",
+                "error:15\n<Idle|WPos:10.000,20.000,5.000|Bf:15,127|FS:0,0>\n",
+            ]
+        )
+
+        with self.assertRaisesRegex(StatusReturnError, "error:15"):
+            mill.current_coordinates()
+        self.assertEqual(mill.ser_mill.write.call_count, 2)
+        mill.ser_mill.write.assert_called_with(b"?")
+
     def test_current_coordinates_converts_mpos_to_wpos(self):
         mill = self._make_mill()
         mill.config["$10"] = "1"  # Force MPos mode

--- a/tests/gantry/driver/test_wpos_enforcement.py
+++ b/tests/gantry/driver/test_wpos_enforcement.py
@@ -4,6 +4,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from gantry.gantry_driver.driver import Mill, wpos_pattern, mpos_pattern, wco_pattern
+from gantry.gantry_driver.exceptions import StatusReturnError
 from gantry.gantry_driver.instruments import Coordinates
 
 
@@ -48,6 +49,28 @@ class TestWposEnforcement(unittest.TestCase):
             "ok\n[MSG:Reset to continue]\n<Idle|WPos:1.000,2.000,3.000|FS:0,0>\n"
         )
         self.assertEqual(status, "<Idle|WPos:1.000,2.000,3.000|FS:0,0>")
+
+    def test_current_status_extracts_status_from_multiline_read(self):
+        mill = self._make_mill()
+        mill.read = MagicMock(
+            return_value="ok\n<Idle|WPos:10.000,20.000,5.000|Bf:15,127|FS:0,0>\n"
+        )
+
+        status = mill.current_status()
+
+        self.assertEqual(status, "<Idle|WPos:10.000,20.000,5.000|Bf:15,127|FS:0,0>")
+
+    def test_current_status_raises_when_chatter_contains_alarm(self):
+        mill = self._make_mill()
+        mill.read = MagicMock(
+            return_value=(
+                "ok\nALARM:2\n"
+                "<Idle|WPos:10.000,20.000,5.000|Bf:15,127|FS:0,0>\n"
+            )
+        )
+
+        with self.assertRaisesRegex(StatusReturnError, "ALARM:2"):
+            mill.current_status()
 
     def test_current_coordinates_converts_mpos_to_wpos(self):
         mill = self._make_mill()

--- a/tests/gantry/driver/test_wpos_enforcement.py
+++ b/tests/gantry/driver/test_wpos_enforcement.py
@@ -61,6 +61,18 @@ class TestWposEnforcement(unittest.TestCase):
         )
         self.assertEqual(status, "<Idle|WPos:4.000,5.000,6.000|FS:0,0>")
 
+    def test_current_status_queries_before_reading_status(self):
+        mill = self._make_mill()
+        mill.ser_mill.write = MagicMock()
+        mill.read = MagicMock(
+            return_value="<Idle|WPos:10.000,20.000,5.000|Bf:15,127|FS:0,0>"
+        )
+
+        status = mill.current_status()
+
+        self.assertEqual(status, "<Idle|WPos:10.000,20.000,5.000|Bf:15,127|FS:0,0>")
+        mill.ser_mill.write.assert_called_once_with(b"?")
+
     def test_current_status_retries_after_incomplete_status_fragment(self):
         mill = self._make_mill()
         mill.ser_mill.write = MagicMock()
@@ -74,7 +86,8 @@ class TestWposEnforcement(unittest.TestCase):
         status = mill.current_status()
 
         self.assertEqual(status, "<Idle|WPos:10.000,20.000,5.000|Bf:15,127|FS:0,0>")
-        mill.ser_mill.write.assert_called_once_with(b"?")
+        self.assertEqual(mill.ser_mill.write.call_count, 2)
+        mill.ser_mill.write.assert_called_with(b"?")
 
     def test_current_coordinates_requeries_after_incomplete_status_fragment(self):
         mill = self._make_mill()

--- a/tests/gantry/driver/test_wpos_enforcement.py
+++ b/tests/gantry/driver/test_wpos_enforcement.py
@@ -50,6 +50,48 @@ class TestWposEnforcement(unittest.TestCase):
         )
         self.assertEqual(status, "<Idle|WPos:1.000,2.000,3.000|FS:0,0>")
 
+    def test_extract_status_line_ignores_incomplete_status_fragment(self):
+        status = Mill._extract_status_line("<Idle|WPos:1.000,2.000,3")
+        self.assertEqual(status, "")
+
+    def test_extract_status_line_skips_incomplete_fragment_before_complete_status(self):
+        status = Mill._extract_status_line(
+            "<Idle|WPos:1.000,2.000,3\n"
+            "<Idle|WPos:4.000,5.000,6.000|FS:0,0>\n"
+        )
+        self.assertEqual(status, "<Idle|WPos:4.000,5.000,6.000|FS:0,0>")
+
+    def test_current_status_retries_after_incomplete_status_fragment(self):
+        mill = self._make_mill()
+        mill.ser_mill.write = MagicMock()
+        mill.read = MagicMock(
+            side_effect=[
+                "<Idle|WPos:10.000,20.000,5",
+                "<Idle|WPos:10.000,20.000,5.000|Bf:15,127|FS:0,0>",
+            ]
+        )
+
+        status = mill.current_status()
+
+        self.assertEqual(status, "<Idle|WPos:10.000,20.000,5.000|Bf:15,127|FS:0,0>")
+        mill.ser_mill.write.assert_called_once_with(b"?")
+
+    def test_current_coordinates_retries_after_incomplete_status_fragment(self):
+        mill = self._make_mill()
+        mill.ser_mill.write = MagicMock()
+        mill.read = MagicMock(
+            side_effect=[
+                "<Idle|WPos:10.000,20.000,5",
+                "<Idle|WPos:10.000,20.000,5.000|Bf:15,127|FS:0,0>",
+            ]
+        )
+
+        coords = mill.current_coordinates()
+
+        self.assertEqual(coords.x, 10.0)
+        self.assertEqual(coords.y, 20.0)
+        self.assertEqual(coords.z, 5.0)
+
     def test_current_status_extracts_status_from_multiline_read(self):
         mill = self._make_mill()
         mill.read = MagicMock(

--- a/tests/gantry/driver/test_wpos_enforcement.py
+++ b/tests/gantry/driver/test_wpos_enforcement.py
@@ -76,7 +76,7 @@ class TestWposEnforcement(unittest.TestCase):
         self.assertEqual(status, "<Idle|WPos:10.000,20.000,5.000|Bf:15,127|FS:0,0>")
         mill.ser_mill.write.assert_called_once_with(b"?")
 
-    def test_current_coordinates_retries_after_incomplete_status_fragment(self):
+    def test_current_coordinates_requeries_after_incomplete_status_fragment(self):
         mill = self._make_mill()
         mill.ser_mill.write = MagicMock()
         mill.read = MagicMock(
@@ -91,6 +91,8 @@ class TestWposEnforcement(unittest.TestCase):
         self.assertEqual(coords.x, 10.0)
         self.assertEqual(coords.y, 20.0)
         self.assertEqual(coords.z, 5.0)
+        self.assertEqual(mill.ser_mill.write.call_count, 2)
+        mill.ser_mill.write.assert_called_with(b"?")
 
     def test_current_status_extracts_status_from_multiline_read(self):
         mill = self._make_mill()

--- a/tests/gantry/driver/test_wpos_enforcement.py
+++ b/tests/gantry/driver/test_wpos_enforcement.py
@@ -31,6 +31,24 @@ class TestWposEnforcement(unittest.TestCase):
         self.assertEqual(coords.y, 20.0)
         self.assertEqual(coords.z, 5.0)
 
+    def test_current_coordinates_extracts_status_from_multiline_read(self):
+        mill = self._make_mill()
+        mill.ser_mill.write = MagicMock()
+        mill.read = MagicMock(
+            return_value="ok\n<Idle|WPos:10.000,20.000,5.000|Bf:15,127|FS:0,0>\n"
+        )
+        coords = mill.current_coordinates()
+        self.assertEqual(coords.x, 10.0)
+        self.assertEqual(coords.y, 20.0)
+        self.assertEqual(coords.z, 5.0)
+        mill.ser_mill.write.assert_called_once_with(b"?")
+
+    def test_extract_status_line_ignores_serial_chatter(self):
+        status = Mill._extract_status_line(
+            "ok\n[MSG:Reset to continue]\n<Idle|WPos:1.000,2.000,3.000|FS:0,0>\n"
+        )
+        self.assertEqual(status, "<Idle|WPos:1.000,2.000,3.000|FS:0,0>")
+
     def test_current_coordinates_converts_mpos_to_wpos(self):
         mill = self._make_mill()
         mill.config["$10"] = "1"  # Force MPos mode


### PR DESCRIPTION
## Summary
- add a small `Mill._extract_status_line()` helper to isolate complete GRBL `<...>` status reports from noisy/multiline serial reads
- use that helper in `current_coordinates()` and `current_status()`, so `ok\n<Idle|WPos:...>` / serial chatter does not cause false retry/failure
- preserve `error` / `alarm` chatter as `StatusReturnError` instead of hiding it behind a later status line
- ignore incomplete/truncated `<...` status fragments and re-query GRBL before trusting coordinate reads
- add focused tests for multiline/chatter status parsing, alarm chatter, truncated fragments, and coordinate re-query behavior

## Why
GRBL/serial reads can include acknowledgement lines, controller chatter, or partial status fragments around a status report. The low-level driver previously required the raw read string to begin with `<`, and `current_coordinates()` could retry by only draining local buffered bytes after a truncated fragment. That made otherwise-valid status reports less predictable.

## Verification
```bash
/tmp/cubos-gantry-venv/bin/python -m pytest tests/gantry/driver/test_wpos_enforcement.py tests/gantry/driver/test_gantry_driver.py -q
```
Output:
```text
.......................................                              [100%]
39 passed, 4 subtests passed in 1.17s
```

```bash
/tmp/cubos-gantry-venv/bin/python -m py_compile src/gantry/gantry_driver/driver.py tests/gantry/driver/test_wpos_enforcement.py
```
No output, exit 0.

```bash
git diff --check
```
No output, exit 0.

## Hardware impact
- Potentially affected hardware: GRBL gantry/CNC serial status polling before coordinate reporting.
- Motion geometry/feed rates: unchanged; this PR changes status parsing/retry behavior only.
- Offline validation: mock/unit tests only; no physical gantry was exercised by Ben.
- Required hardware validation before trusting on a real setup: on a connected GRBL gantry, confirm repeated `current_coordinates()` / `current_status()` calls still return WPos reliably after normal `ok` chatter, idle polling, and any observed serial fragmentation.

## Notes
- Base: `staging` at `68384188912e0fe6d50345a026d5ed3855bf0e69`
- Branch: `ben/gantry-driver-position-parse-20260501`
- Latest local commit: `e523037a503ea4e820da894d80420cb8a3cdd815`
- Validation used temp venv at `/tmp/cubos-gantry-venv`.
