### PR TITLE
Sterling N=1 instrument test: deck-ref scan, collision avoidance, validator fixes

### DIFF
--- a/configs/gantry/cub_xl_sterling.yaml
+++ b/configs/gantry/cub_xl_sterling.yaml
@@ -27,7 +27,7 @@ grbl_settings:
   max_travel_x: 306.0
   max_travel_y: 300.0
   max_travel_z: 115.0
-  soft_limits: true
+  soft_limits: false
 
 instruments:
   asmi:
@@ -37,8 +37,8 @@ instruments:
     offset_x: 0.0
     offset_y: 0.0
     depth: 0.0
-    measurement_height: 26.0
-    safe_approach_height: 35.0
+    measurement_height: 2.0
+    safe_approach_height: 5.0
     force_threshold: -50
     sensor_channels:
       - 1

--- a/configs/protocol/sterling_vial_scan.yaml
+++ b/configs/protocol/sterling_vial_scan.yaml
@@ -1,20 +1,11 @@
 # Sterling vial-position scan.
 #
-# This is a motion-only protocol: it visits the configured vial XY centers at a
-# high deck-frame Z plane without descending into the vials or touching ASMI.
-# Order alternates from the front and back of the 8 configured vial positions:
-# 1, 8, 2, 7, 3, 6, 4, 5.
+# Visits each vial position using coordinates from sterling_deck.yaml.
+# Positions are resolved via deck.resolve("vial_holder.vial_N").
+# Order alternates from front and back: 1, 8, 2, 7, 3, 6, 4, 5.
 
 positions:
   park_position: [280.0, 280.0, 85.0]
-  vial_1_scan: [223.0, 25.0, 40.0]
-  vial_2_scan: [223.0, 58.5, 40.0]
-  vial_3_scan: [223.0, 92.0, 40.0]
-  vial_4_scan: [223.0, 125.5, 40.0]
-  vial_5_scan: [223.0, 159.0, 40.0]
-  vial_6_scan: [223.0, 192.5, 40.0]
-  vial_7_scan: [223.0, 226.0, 40.0]
-  vial_8_scan: [223.0, 259.5, 40.0]
 
 protocol:
   - home:
@@ -26,43 +17,35 @@ protocol:
 
   - move:
       instrument: asmi
-      position: vial_1_scan
-      travel_z: 85.0
+      position: vial_holder.vial_1
 
   - move:
       instrument: asmi
-      position: vial_8_scan
-      travel_z: 85.0
+      position: vial_holder.vial_8
 
   - move:
       instrument: asmi
-      position: vial_2_scan
-      travel_z: 85.0
+      position: vial_holder.vial_2
 
   - move:
       instrument: asmi
-      position: vial_7_scan
-      travel_z: 85.0
+      position: vial_holder.vial_7
 
   - move:
       instrument: asmi
-      position: vial_3_scan
-      travel_z: 85.0
+      position: vial_holder.vial_3
 
   - move:
       instrument: asmi
-      position: vial_6_scan
-      travel_z: 85.0
+      position: vial_holder.vial_6
 
   - move:
       instrument: asmi
-      position: vial_4_scan
-      travel_z: 85.0
+      position: vial_holder.vial_4
 
   - move:
       instrument: asmi
-      position: vial_5_scan
-      travel_z: 85.0
+      position: vial_holder.vial_5
 
   - move:
       instrument: asmi

--- a/configs/protocol/sterling_x_traverse.yaml
+++ b/configs/protocol/sterling_x_traverse.yaml
@@ -1,34 +1,47 @@
-# Sterling X-axis traverse for collision avoidance testing.
-# Moves the gantry from x_min to x_max at a safe Z clearance plane.
+# Sterling X-axis collision avoidance test.
+#
+# Scenario: gantry descends to z_min at x_mid, then moves to x_max at
+# z_max. Without travel_z on step 4, the gantry X-traverses at z_min
+# (its current Z from step 3) before lifting — this would collide with
+# any labware along the X path.
+#
+# The validator currently does NOT catch this because it checks each
+# step independently without tracking the gantry's Z from prior steps.
 
 positions:
-  park: [280.0, 280.0, 85.0]
-  x_min: [0.0, 150.0, 40.0]
-  x_max: [306.0, 150.0, 40.0]
+  park:  [280.0, 280.0, 85.0]
+  x_min_high: [0.0, 150.0, 85.0]
+  x_mid_low:  [153.0, 150.0, 30.0]
+  x_max_high: [306.0, 150.0, 85.0]
 
 protocol:
   - home:
 
+  # Step 1: park safely
   - move:
       instrument: asmi
       position: park
       travel_z: 85.0
 
+  # Step 2: move to x_min at safe height
   - move:
       instrument: asmi
-      position: x_min
-      travel_z: 40.0
+      position: x_min_high
+      travel_z: 85.0
 
+  # Step 3: descend to z=30 at x_mid (below labware)
   - move:
       instrument: asmi
-      position: x_max
-      travel_z: 40.0
+      position: x_mid_low
+      travel_z: 85.0
 
+  # Step 4: BUG — no travel_z, so gantry X-traverses at z=30 (from
+  # step 3) before lifting to z=85. Would collide with vials at z~57.
   - move:
       instrument: asmi
-      position: x_min
-      travel_z: 40.0
+      position: x_max_high
 
+  # Step 5: return to park
   - move:
       instrument: asmi
       position: park

--- a/configs/protocol/sterling_x_traverse.yaml
+++ b/configs/protocol/sterling_x_traverse.yaml
@@ -1,0 +1,37 @@
+# Sterling X-axis traverse for collision avoidance testing.
+# Moves the gantry from x_min to x_max at a safe Z clearance plane.
+
+positions:
+  park: [280.0, 280.0, 85.0]
+  x_min: [0.0, 150.0, 40.0]
+  x_max: [306.0, 150.0, 40.0]
+
+protocol:
+  - home:
+
+  - move:
+      instrument: asmi
+      position: park
+      travel_z: 85.0
+
+  - move:
+      instrument: asmi
+      position: x_min
+      travel_z: 40.0
+
+  - move:
+      instrument: asmi
+      position: x_max
+      travel_z: 40.0
+
+  - move:
+      instrument: asmi
+      position: x_min
+      travel_z: 40.0
+
+  - move:
+      instrument: asmi
+      position: park
+      travel_z: 85.0
+
+  - home:

--- a/setup/run_sterling_scan.py
+++ b/setup/run_sterling_scan.py
@@ -1,0 +1,22 @@
+"""Run the Sterling vial scan protocol.
+
+Usage:
+    python setup/run_sterling_scan.py
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(project_root))
+sys.path.insert(0, str(project_root / "src"))
+
+from setup.run_protocol import main as run_protocol_main
+
+GANTRY = "configs/gantry/cub_xl_sterling.yaml"
+DECK = "configs/deck/sterling_deck.yaml"
+PROTOCOL = "configs/protocol/sterling_vial_scan.yaml"
+
+if __name__ == "__main__":
+    sys.argv = [sys.argv[0], GANTRY, DECK, PROTOCOL]
+    run_protocol_main()

--- a/src/board/board.py
+++ b/src/board/board.py
@@ -86,8 +86,8 @@ class Board:
     ) -> None:
         """Travel *instrument* to the approach height above a labware target.
 
-        Emits a single ``move`` with ``travel_z = safe_approach_height``.
-        The gantry lifts/lowers to that absolute deck-frame Z plane at
+        Emits a single ``move`` with ``travel_z = labware.z -
+        safe_approach_height``. The gantry lifts/lowers to approach Z at
         the current XY, travels XY at approach Z, and ends above the
         target — not engaged with it. Higher-level commands
         (``measure``, ``aspirate``, ``scan``, ...) follow up with a raw
@@ -103,7 +103,7 @@ class Board:
         instr = self._resolve_instrument(instrument)
         x, y, z = self._resolve_position(labware)
         self._validate_finite_xyz(x, y, z, instr.name)
-        approach_z = instr.safe_approach_height
+        approach_z = z - instr.safe_approach_height
         self.move(instr, (x, y, approach_z), travel_z=approach_z)
 
     def _validate_finite_xyz(self, x: float, y: float, z: float, instr_name: str) -> None:

--- a/src/validation/protocol_semantics.py
+++ b/src/validation/protocol_semantics.py
@@ -267,7 +267,7 @@ def _validate_move_waypoints(
                 f"position {position!r} cannot be resolved on the deck: {exc}",
             ))
             return violations
-        approach_z = board.instruments[instrument].safe_approach_height
+        approach_z = coord.z - board.instruments[instrument].safe_approach_height
         target = (coord.x, coord.y, approach_z)
 
     if target is None:

--- a/tests/board/test_board.py
+++ b/tests/board/test_board.py
@@ -312,9 +312,9 @@ class TestBoardMoveToLabware:
 
         assert gantry.move_to.call_count == 1
         call = gantry.move_to.call_args
-        # Deck-origin +Z-up: safe_approach_height is an absolute Z plane.
-        assert call.args == (100.0, 50.0, 3.0)
-        assert call.kwargs == {"travel_z": 3.0}
+        # approach_z = labware.z - safe_approach_height = 20 - 3 = 17.
+        assert call.args == (100.0, 50.0, 17.0)
+        assert call.kwargs == {"travel_z": 17.0}
 
     def test_contact_instrument_travel_at_approach_above_action(self):
         """Contact instrument with safe_approach > measurement: travel_z
@@ -326,9 +326,9 @@ class TestBoardMoveToLabware:
 
         assert gantry.move_to.call_count == 1
         call = gantry.move_to.call_args
-        # approach z is the absolute safe_approach_height plane.
-        assert call.args == (100.0, 50.0, 20.0)
-        assert call.kwargs == {"travel_z": 20.0}
+        # approach_z = labware.z - safe_approach_height = 30 - 20 = 10.
+        assert call.args == (100.0, 50.0, 10.0)
+        assert call.kwargs == {"travel_z": 10.0}
 
     def test_applies_instrument_xy_offsets_and_depth(self):
         """Instrument offsets shift gantry coords; depth shifts both
@@ -342,7 +342,7 @@ class TestBoardMoveToLabware:
         board.move_to_labware("probe", _mock_labware(x=100, y=50, z=30))
 
         call = gantry.move_to.call_args
-        # approach tip z = 15 absolute; gantry z = 15 + depth(2) = 17.
+        # approach_z = 30 - 15 = 15; gantry z = 15 + depth(2) = 17.
         # gantry x = 100 - 10 = 90; gantry y = 50 - (-5) = 55.
         assert call.args == (90.0, 55.0, 17.0)
         assert call.kwargs == {"travel_z": 17.0}
@@ -355,8 +355,9 @@ class TestBoardMoveToLabware:
 
         assert gantry.move_to.call_count == 1
         call = gantry.move_to.call_args
-        assert call.args == (50.0, 40.0, 2.0)
-        assert call.kwargs == {"travel_z": 2.0}
+        # approach_z = 10 - 2 = 8.
+        assert call.args == (50.0, 40.0, 8.0)
+        assert call.kwargs == {"travel_z": 8.0}
 
     def test_rejects_nan_position_z(self):
         """NaN in position z is caught (via Board.move's validation)."""

--- a/tests/validation/test_protocol_semantics.py
+++ b/tests/validation/test_protocol_semantics.py
@@ -268,6 +268,36 @@ def test_move_to_unknown_named_position_emits_violation():
     assert any("cannot be resolved" in v.message for v in violations), violations
 
 
+def test_move_deck_target_uses_coord_z_minus_safe_approach():
+    """Deck-target moves compute approach_z = coord.z - safe_approach_height.
+
+    Regression: the validator previously used safe_approach_height raw as
+    the z coordinate, which produced false violations for valid targets.
+    """
+    instr = _instrument("asmi")
+    instr.safe_approach_height = 5.0
+    board, deck = _board_and_deck(instr)
+    # plate A1 is at z=73.0, approach_z = 73 - 5 = 68 → within [0, 100].
+    gantry = _gantry_config(z_max=100.0)
+    protocol = _move_step(position="plate.A1")
+
+    assert validate_protocol_semantics(protocol, board, deck, gantry) == []
+
+
+def test_move_deck_target_approach_z_violation():
+    """When coord.z - safe_approach_height falls outside bounds, flag it."""
+    instr = _instrument("asmi")
+    instr.safe_approach_height = 5.0
+    board, deck = _board_and_deck(instr)
+    # plate A1 at z=73.0, approach_z = 73 - 5 = 68 → violates z_max=60.
+    gantry = _gantry_config(z_max=60.0)
+    protocol = _move_step(position="plate.A1")
+
+    violations = validate_protocol_semantics(protocol, board, deck, gantry)
+
+    assert any("z" in v.message for v in violations), violations
+
+
 def test_move_without_gantry_config_skips_bound_check():
     """Default-None gantry preserves backward compatibility with older callers."""
     board, deck = _board_and_deck()

--- a/tests/validation/test_structure_clearance.py
+++ b/tests/validation/test_structure_clearance.py
@@ -97,3 +97,49 @@ def test_scan_entry_at_structure_clearance_passes():
         _deck(),
         _gantry(clearance_z=85.0),
     ) == []
+
+
+def _move_protocol(travel_z: float) -> Protocol:
+    return Protocol([
+        ProtocolStep(
+            index=0,
+            command_name="move",
+            handler=lambda *a, **k: None,
+            args={
+                "instrument": "asmi",
+                "position": [100.0, 150.0, 40.0],
+                "travel_z": travel_z,
+            },
+        )
+    ])
+
+
+def test_move_travel_z_below_structure_clearance_fails():
+    """travel_z=40 with structure_clearance_z=85 must be rejected."""
+    violations = validate_protocol_semantics(
+        _move_protocol(travel_z=40.0),
+        _board(),
+        _deck(),
+        _gantry(clearance_z=85.0),
+    )
+
+    assert len(violations) == 1
+    assert "structure_clearance_z" in violations[0].message
+
+
+def test_move_travel_z_at_structure_clearance_passes():
+    assert validate_protocol_semantics(
+        _move_protocol(travel_z=85.0),
+        _board(),
+        _deck(),
+        _gantry(clearance_z=85.0),
+    ) == []
+
+
+def test_move_travel_z_above_structure_clearance_passes():
+    assert validate_protocol_semantics(
+        _move_protocol(travel_z=90.0),
+        _board(),
+        _deck(),
+        _gantry(clearance_z=85.0),
+    ) == []

--- a/tests/validation/test_structure_clearance.py
+++ b/tests/validation/test_structure_clearance.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from board.board import Board
 from deck.deck import Deck
 from deck.labware.labware import Coordinate3D
@@ -143,3 +145,52 @@ def test_move_travel_z_above_structure_clearance_passes():
         _deck(),
         _gantry(clearance_z=85.0),
     ) == []
+
+
+@pytest.mark.xfail(
+    reason="Validator does not track Z state between steps — "
+    "step 3 leaves gantry at z=30, step 4 X-traverses at z=30 "
+    "without travel_z, which would collide with labware at z=57.",
+    strict=True,
+)
+def test_move_without_travel_z_after_low_z_step_should_fail():
+    """Gantry descends to z=30, then moves X without travel_z.
+
+    The X traversal happens at z=30 (current Z from prior step), which
+    is below structure_clearance_z=85. Validation should catch this but
+    currently does not because it checks steps independently.
+    """
+    board, deck = _board(), _deck()
+    gantry = _gantry(clearance_z=85.0)
+    protocol = Protocol([
+        # Step 0: descend to z=30 at x=50
+        ProtocolStep(
+            index=0,
+            command_name="move",
+            handler=lambda *a, **k: None,
+            args={
+                "instrument": "asmi",
+                "position": [50.0, 100.0, 30.0],
+                "travel_z": 85.0,
+            },
+        ),
+        # Step 1: move to x=250 at z=85 — BUT no travel_z, so gantry
+        # X-traverses at z=30 (its current Z) before lifting.
+        ProtocolStep(
+            index=1,
+            command_name="move",
+            handler=lambda *a, **k: None,
+            args={
+                "instrument": "asmi",
+                "position": [250.0, 100.0, 85.0],
+            },
+        ),
+    ])
+
+    violations = validate_protocol_semantics(protocol, board, deck, gantry)
+
+    assert any("structure_clearance" in v.message or "travel" in v.message
+               for v in violations), (
+        "Validator should flag X traversal at z=30 (below clearance=85) "
+        f"but found no violations: {violations}"
+    )


### PR DESCRIPTION
## Summary
- **sterling_vial_scan.yaml**: resolve vial positions from deck (`vial_holder.vial_N`) instead of duplicating coordinates in the protocol
- **sterling_x_traverse.yaml**: X-axis traverse protocol for collision avoidance testing — documents the inter-step collision gap where the validator doesn't track Z state between steps
- **run_sterling_scan.py**: convenience script to run the sterling scan protocol
- **Fix `move_to_labware`**: compute `approach_z = z - safe_approach_height` (relative to labware) instead of using `safe_approach_height` as absolute Z — was sending gantry to z=5 instead of z=52
- **Fix semantic validator**: deck-target moves now validate `coord.z - safe_approach_height` instead of raw `safe_approach_height`
- **Disable `soft_limits`** in `cub_xl_sterling.yaml` to match controller ($20=0)

## Test plan
- [x] `test_move_deck_target_uses_coord_z_minus_safe_approach` — verifies corrected validator
- [x] `test_move_deck_target_approach_z_violation` — verifies out-of-bounds detection
- [x] `test_move_travel_z_below_structure_clearance_fails` — structure clearance rejection
- [x] `test_move_travel_z_at/above_structure_clearance_passes` — boundary cases
- [x] `test_move_without_travel_z_after_low_z_step_should_fail` (xfail) — documents inter-step collision gap
- [x] Board `move_to_labware` tests updated for relative approach_z
- [x] Sterling mock validation passes
- [x] Full test suite: 1025 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)