### PR TITLE
Add well_depth_mm (inside well depth) to WellPlate

### DIFF
--- a/progress/2026-05-05-well-depth-mm.md
+++ b/progress/2026-05-05-well-depth-mm.md
@@ -1,0 +1,72 @@
+# 2026-05-05 — Add `well_depth_mm` to WellPlate
+
+## Scope
+
+`WellPlate` already carries an `height_mm` (outer plate height, rim → underside
+of plate including skirt/feet). It did **not** carry the *inside* depth (rim →
+floor where the sample sits), even though analysis pipelines need that to
+compute sample thickness from a contact point. ASMI's analysis path was
+working around this with a manual `well_bottom_z` knob in `analysis.yaml` —
+defaulting to `-85.0` (positive-down legacy convention) and silently wrong
+under the new deck-origin +Z-up frame.
+
+This commit teaches WellPlate the inside depth so any consumer can derive
+`well_bottom_z = a1.z - well_depth_mm` from the plate object directly.
+
+## What changed
+
+- `src/deck/yaml_schema.py` — add `well_depth_mm: Optional[float]` (gt=0) to
+  both `WellPlateYamlEntry` and `NestedWellPlateYamlEntry`. Backward-compatible:
+  default `None`; existing deck YAMLs that don't declare it keep loading.
+- `src/deck/labware/well_plate.py` — add `well_depth_mm: Optional[float]`
+  field + positive-value field validator.
+- `src/deck/loader.py` — `_build_well_plate` already auto-wires matching
+  fields via `_entry_kwargs_for_model`; only `_build_nested_well_plate`
+  needed an explicit pass-through.
+- `src/deck/labware/definitions/sbs_96_wellplate/SBS96WellPlate.yaml` —
+  declare `well_depth_mm: 10.67` (standard flat-bottom shallow SBS96, e.g.
+  Corning 3585). Documents the rim-vs-inside distinction in comments.
+- `src/deck/labware/definitions/sbs_96_wellplate/README.md` — add the inside
+  depth to the dimensions table and call out the (outer, inside) pair as
+  intentionally separate.
+
+## Tests
+
+`tests/test_deck_loader.py`:
+
+- `test_well_plate_carries_well_depth_mm_to_plate_object` — explicit
+  `well_depth_mm: 10.67` flows from yaml → entry → plate object.
+- `test_well_plate_well_depth_mm_is_optional_default_none` — pre-existing
+  deck YAMLs without the field still load; plate's `well_depth_mm` is None.
+- `test_well_plate_well_depth_mm_must_be_positive` — negative values fail
+  schema validation.
+- `test_load_name_sbs_96_wellplate_carries_default_well_depth_mm` —
+  `load_name: sbs_96_wellplate` users get the registry default (10.67) without
+  per-deck overrides.
+
+Full suite: 1033 passed, 4 subtests passed.
+
+## Hardware impact
+
+None directly. The new field is metadata; no motion or instrument code reads
+it yet. ASMI's analysis pipeline will be wired up in a follow-up commit on
+the ASMI_new side once this lands.
+
+## Why a separate field instead of overloading `height_mm`
+
+`height_mm` already describes the outer plate height (calibration rim →
+underside of plate, including skirt). The inside well depth is a different
+quantity (rim → inside floor where the sample sits), and the two diverge by
+a few millimeters depending on the well-bottom geometry and skirt thickness.
+Mixing them would silently break either the existing footprint/clearance
+math or the new sample-thickness math. Two separate fields keep both
+explicit.
+
+## Open follow-ups
+
+- ASMI_new: drop `measurement.well_bottom_z` from `analysis.yaml` and update
+  `src/analysis.py` + `scripts/analyze_from_db.py` to compute it as
+  `plate.a1.z - plate.well_depth_mm`. (Tracked separately, after this PR
+  lands.)
+- Add `well_depth_mm` to other well-plate definitions if/when added (deep-well
+  2 mL ≈ 38 mm; V-bottom ≈ vertex-depth dependent).

--- a/src/deck/labware/definitions/sbs_96_wellplate/README.md
+++ b/src/deck/labware/definitions/sbs_96_wellplate/README.md
@@ -18,7 +18,8 @@ Maps to `cubos.src.deck.labware.well_plate.WellPlate`.
 | Attribute | Value | Notes |
 | --- | --- | --- |
 | Outer footprint | 127.76 × 85.47 mm | ANSI SLAS 1-2004 |
-| Plate height | 14.35 mm | Typical shallow-well plate; override for deep wells |
+| Plate height (outer) | 14.35 mm | Rim → underside of plate; override for deep wells |
+| Well depth (inside) | 10.67 mm | Rim → inside floor; flat-bottom shallow SBS96 |
 | Well grid | 8 × 12 (A1 – H12) | Letters are rows, numbers are columns |
 | Well pitch | 9.0 mm in both x and y | ANSI SLAS 4-2004 |
 | A1 offset from plate corner | (14.38, 11.24) mm | Template placeholder in `calibration.a1` |
@@ -43,7 +44,11 @@ labware:
 
 Vendor-specific variants (e.g. Corning 360 µL round-bottom, deep-well
 2 mL, skirt height differences) should override the relevant fields
-(`height_mm`, `capacity_ul`, `working_volume_ul`) in the deck YAML.
+(`height_mm`, `well_depth_mm`, `capacity_ul`, `working_volume_ul`) in
+the deck YAML. The pair `(height_mm, well_depth_mm)` is intentionally
+separate: `height_mm` is the outer dimension (rim → underside),
+`well_depth_mm` is the inside (rim → sample floor). Analysis pipelines
+use `a1.z - well_depth_mm` to compute sample thickness.
 
 ## Compatibility
 

--- a/src/deck/labware/definitions/sbs_96_wellplate/SBS96WellPlate.yaml
+++ b/src/deck/labware/definitions/sbs_96_wellplate/SBS96WellPlate.yaml
@@ -18,7 +18,10 @@ rows: 8
 columns: 12
 length_mm: 127.76
 width_mm: 85.47
-height_mm: 14.35
+height_mm: 14.35           # OUTER plate height (rim → underside of plate)
+well_depth_mm: 10.67       # INSIDE well depth (rim → inside floor where sample sits).
+                           # Standard flat-bottom shallow SBS96 (Corning 3585 etc.).
+                           # Override for deep-well/V-bottom/round-bottom variants.
 calibration:
   a1: { x: 14.38, y: 11.24 }   # SBS A1 offset from plate corner
   a2: { x: 23.38, y: 11.24 }   # next column (a1.x + x_offset_mm)

--- a/src/deck/labware/well_plate.py
+++ b/src/deck/labware/well_plate.py
@@ -21,16 +21,23 @@ class WellPlate(Labware):
     # Geometry — optional metadata, not used for well position computation.
     length_mm: Optional[float] = Field(None, description="Overall plate length in millimeters.")
     width_mm: Optional[float] = Field(None, description="Overall plate width in millimeters.")
-    height_mm: Optional[float] = Field(None, description="Z position of the plate surface (absolute WPos).")
+    height_mm: Optional[float] = Field(
+        None,
+        description=(
+            "Outer plate height in millimeters — calibration rim to underside "
+            "of the plate (including skirt/feet). A dimension, not a deck-frame "
+            "Z coordinate."
+        ),
+    )
     well_depth_mm: Optional[float] = Field(
         None,
-        gt=0,
         description=(
-            "Inside well depth in millimeters from the calibration rim down "
-            "to the inside floor where the sample sits. Distinct from "
-            "`height_mm` (outer plate height); for SBS96 the outer is "
-            "~14.35 mm but inside depth is ~10.67 mm. Analysis pipelines "
-            "compute sample thickness as `a1.z - well_depth_mm`."
+            "Inside well depth in millimeters from the calibration rim to the "
+            "inside floor where the sample sits. Distinct from `height_mm` "
+            "(outer plate height): outer and inside depth differ by a few "
+            "millimeters depending on well-bottom geometry and skirt thickness. "
+            "External analysis consumers use it to compute the sample-floor Z "
+            "from the deck-frame rim Z."
         ),
     )
     rows: int = Field(
@@ -63,6 +70,24 @@ class WellPlate(Labware):
         if (self.capacity_ul is not None and self.working_volume_ul is not None
                 and self.working_volume_ul > self.capacity_ul):
             raise ValueError("working_volume_ul must be <= capacity_ul.")
+        return self
+
+    @model_validator(mode="after")
+    def _validate_well_depth_le_height(self) -> "WellPlate":
+        # Inside well depth cannot exceed outer plate height; physically the
+        # inside floor sits *above* the underside of the plate by at least the
+        # bottom-wall thickness. Catches the realistic miscalibration bug
+        # (e.g. swapped values) that gt=0 alone wouldn't.
+        if (
+            self.well_depth_mm is not None
+            and self.height_mm is not None
+            and self.well_depth_mm > self.height_mm
+        ):
+            raise ValueError(
+                f"well_depth_mm ({self.well_depth_mm}) must be <= height_mm "
+                f"({self.height_mm}) — inside floor cannot sit below the plate "
+                f"underside."
+            )
         return self
 
     @field_validator("length_mm", "width_mm", "well_depth_mm")

--- a/src/deck/labware/well_plate.py
+++ b/src/deck/labware/well_plate.py
@@ -22,6 +22,17 @@ class WellPlate(Labware):
     length_mm: Optional[float] = Field(None, description="Overall plate length in millimeters.")
     width_mm: Optional[float] = Field(None, description="Overall plate width in millimeters.")
     height_mm: Optional[float] = Field(None, description="Z position of the plate surface (absolute WPos).")
+    well_depth_mm: Optional[float] = Field(
+        None,
+        gt=0,
+        description=(
+            "Inside well depth in millimeters from the calibration rim down "
+            "to the inside floor where the sample sits. Distinct from "
+            "`height_mm` (outer plate height); for SBS96 the outer is "
+            "~14.35 mm but inside depth is ~10.67 mm. Analysis pipelines "
+            "compute sample thickness as `a1.z - well_depth_mm`."
+        ),
+    )
     rows: int = Field(
         ...,
         gt=0,
@@ -54,7 +65,7 @@ class WellPlate(Labware):
             raise ValueError("working_volume_ul must be <= capacity_ul.")
         return self
 
-    @field_validator("length_mm", "width_mm")
+    @field_validator("length_mm", "width_mm", "well_depth_mm")
     def _validate_positive_dimension(cls, value: Optional[float], info):  # type: ignore[override]
         if value is not None and value <= 0:
             raise ValueError(f"{info.field_name} must be positive.")

--- a/src/deck/loader.py
+++ b/src/deck/loader.py
@@ -422,6 +422,7 @@ def _build_nested_well_plate(
         length_mm=entry.length_mm,
         width_mm=entry.width_mm,
         height_mm=entry.height_mm,
+        well_depth_mm=entry.well_depth_mm,
         rows=entry.rows,
         columns=entry.columns,
         wells=_derive_wells_from_calibration(entry, resolved_z=resolved_z),

--- a/src/deck/yaml_schema.py
+++ b/src/deck/yaml_schema.py
@@ -35,6 +35,12 @@ class WellPlateYamlEntry(BaseModel):
     length_mm: Optional[float] = None
     width_mm: Optional[float] = None
     height_mm: Optional[float] = None
+    # Inside well depth from rim (calibration anchor) to inside floor where the
+    # sample sits. Lets analysis pipelines compute sample thickness as
+    # `a1.z - well_depth_mm` rather than carrying a manual `well_bottom_z`.
+    # Distinct from `height_mm` (outer plate height) — for typical SBS96 the
+    # outer is ~14.35 mm but inside depth is ~10.67 mm.
+    well_depth_mm: Optional[float] = Field(default=None, gt=0)
     height: Optional[float] = Field(default=None, gt=0)
     # Backward compatibility: top-level A1 is accepted but deprecated.
     a1: Optional[_YamlPoint3D] = None
@@ -134,6 +140,7 @@ class NestedWellPlateYamlEntry(BaseModel):
     length_mm: Optional[float] = None
     width_mm: Optional[float] = None
     height_mm: Optional[float] = None
+    well_depth_mm: Optional[float] = Field(default=None, gt=0)
     calibration: _YamlCalibrationPoints
     x_offset_mm: float = Field(..., gt=0)
     y_offset_mm: float = Field(..., gt=0)

--- a/src/deck/yaml_schema.py
+++ b/src/deck/yaml_schema.py
@@ -35,11 +35,11 @@ class WellPlateYamlEntry(BaseModel):
     length_mm: Optional[float] = None
     width_mm: Optional[float] = None
     height_mm: Optional[float] = None
-    # Inside well depth from rim (calibration anchor) to inside floor where the
-    # sample sits. Lets analysis pipelines compute sample thickness as
-    # `a1.z - well_depth_mm` rather than carrying a manual `well_bottom_z`.
-    # Distinct from `height_mm` (outer plate height) — for typical SBS96 the
-    # outer is ~14.35 mm but inside depth is ~10.67 mm.
+    # Inside well depth from rim (calibration anchor) to inside floor where
+    # the sample sits. Distinct from `height_mm` (outer plate height): outer
+    # and inside depth differ by a few millimeters depending on well-bottom
+    # geometry and skirt thickness. External analysis consumers compute the
+    # sample-floor Z as the deck-frame rim Z minus this depth.
     well_depth_mm: Optional[float] = Field(default=None, gt=0)
     height: Optional[float] = Field(default=None, gt=0)
     # Backward compatibility: top-level A1 is accepted but deprecated.
@@ -77,6 +77,13 @@ class WellPlateYamlEntry(BaseModel):
         if (self.capacity_ul is not None and self.working_volume_ul is not None
                 and self.working_volume_ul > self.capacity_ul):
             raise ValueError("working_volume_ul must be <= capacity_ul.")
+        if (self.well_depth_mm is not None and self.height_mm is not None
+                and self.well_depth_mm > self.height_mm):
+            raise ValueError(
+                f"well_depth_mm ({self.well_depth_mm}) must be <= height_mm "
+                f"({self.height_mm}) — inside floor cannot sit below the plate "
+                f"underside."
+            )
         return self
 
 
@@ -178,6 +185,13 @@ class NestedWellPlateYamlEntry(BaseModel):
             and self.working_volume_ul > self.capacity_ul
         ):
             raise ValueError("working_volume_ul must be <= capacity_ul.")
+        if (self.well_depth_mm is not None and self.height_mm is not None
+                and self.well_depth_mm > self.height_mm):
+            raise ValueError(
+                f"well_depth_mm ({self.well_depth_mm}) must be <= height_mm "
+                f"({self.height_mm}) — inside floor cannot sit below the plate "
+                f"underside."
+            )
         return self
 
 

--- a/tests/test_deck_loader.py
+++ b/tests/test_deck_loader.py
@@ -1292,22 +1292,75 @@ def test_well_plate_well_depth_mm_is_optional_default_none():
         Path(path).unlink(missing_ok=True)
 
 
-def test_well_plate_well_depth_mm_must_be_positive():
-    """Negative or zero inside depth is nonsensical and should fail validation."""
+def test_well_plate_well_depth_mm_negative_is_rejected():
+    """Strictly negative inside depth is nonsensical and must fail."""
     bad_yaml = WELL_DEPTH_DECK_YAML.replace("well_depth_mm: 10.67", "well_depth_mm: -1.0")
     with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
         f.write(bad_yaml)
         path = f.name
     try:
-        with pytest.raises(Exception, match="well_depth_mm"):
+        with pytest.raises(ValidationError, match="well_depth_mm"):
             load_deck_from_yaml(path)
     finally:
         Path(path).unlink(missing_ok=True)
 
 
+def test_well_plate_well_depth_mm_zero_is_rejected():
+    """Boundary case: `gt=0` (not `ge=0`) means zero must also fail.
+
+    Pinning the boundary explicitly so `gt=0 -> ge=0` regressions are caught.
+    """
+    bad_yaml = WELL_DEPTH_DECK_YAML.replace("well_depth_mm: 10.67", "well_depth_mm: 0")
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        f.write(bad_yaml)
+        path = f.name
+    try:
+        with pytest.raises(ValidationError, match="well_depth_mm"):
+            load_deck_from_yaml(path)
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_well_plate_well_depth_mm_cannot_exceed_height_mm():
+    """Inside depth must fit within outer plate height.
+
+    Catches the realistic miscalibration bug (e.g. swapped values) that the
+    `gt=0` per-field check alone would let through. Uses a YAML that sets a
+    sensible outer `height_mm` and a clearly-too-large `well_depth_mm`.
+    """
+    bad_yaml = WELL_DEPTH_DECK_YAML.replace("well_depth_mm: 10.67", "well_depth_mm: 50.0")
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        f.write(bad_yaml)
+        path = f.name
+    try:
+        with pytest.raises(ValidationError, match=r"well_depth_mm.*height_mm"):
+            load_deck_from_yaml(path)
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_well_plate_direct_construction_rejects_negative_well_depth_mm():
+    """The runtime `WellPlate` model also enforces positivity, not just the
+    YAML schema. Guards against future test-only or programmatic constructors
+    bypassing schema validation.
+    """
+    a1 = Coordinate3D(x=10.0, y=10.0, z=25.9)
+    wells = {f"{r}{c}": a1 for r in "ABCDEFGH" for c in range(1, 13)}
+    with pytest.raises(ValidationError, match="well_depth_mm"):
+        WellPlate(
+            name="bad",
+            rows=8, columns=12,
+            wells=wells,
+            well_depth_mm=-1.0,
+        )
+
+
 def test_load_name_sbs_96_wellplate_carries_default_well_depth_mm():
     """The shipped SBS96 definition supplies a sane default inside depth so
     `load_name: sbs_96_wellplate` users get it without per-deck overrides.
+
+    The exact value (10.67 mm) lives in `sbs_96_wellplate/SBS96WellPlate.yaml`;
+    this test pins it so a registry typo is caught.
     """
     yaml_str = """
 labware:
@@ -1323,8 +1376,72 @@ labware:
     try:
         deck = load_deck_from_yaml(path)
         plate = deck["plate"]
-        assert plate.well_depth_mm is not None
-        # Standard flat-bottom shallow SBS96 inside depth.
-        assert 9.0 < plate.well_depth_mm < 12.0
+        assert plate.well_depth_mm == pytest.approx(10.67)
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_load_name_sbs_96_wellplate_well_depth_mm_user_override_wins():
+    """Deck-level `well_depth_mm` overrides the registry default.
+
+    Regression guard for the registry merge order — confirms user-supplied
+    fields win over the definition's defaults (matches the comment in
+    `_resolve_load_names`).
+    """
+    yaml_str = """
+labware:
+  plate:
+    load_name: sbs_96_wellplate
+    well_depth_mm: 8.5
+    calibration:
+      a1: { x: 10.0, y: 10.0, z: 25.9 }
+      a2: { x: 19.0, y: 10.0, z: 25.9 }
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        f.write(yaml_str)
+        path = f.name
+    try:
+        deck = load_deck_from_yaml(path)
+        plate = deck["plate"]
+        assert plate.well_depth_mm == pytest.approx(8.5)
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_nested_well_plate_carries_well_depth_mm():
+    """Wellplates declared inside a holder must also carry `well_depth_mm`
+    through to the WellPlate model.
+
+    The top-level `_build_well_plate` auto-wires fields via
+    `_entry_kwargs_for_model`, but `_build_nested_well_plate` is an explicit
+    constructor — without this test, dropping the field there would not be
+    caught by any other case.
+    """
+    yaml_str = """
+labware:
+  plate_holder:
+    type: well_plate_holder
+    name: plate_holder
+    location: { x: 221.75, y: 78.5, z: 183.0 }
+    well_plate:
+      model_name: panda_96_wellplate
+      rows: 2
+      columns: 2
+      well_depth_mm: 9.5
+      calibration:
+        a1: { x: 221.75, y: 78.5 }
+        a2: { x: 230.75, y: 78.5 }
+      x_offset_mm: 9.0
+      y_offset_mm: 9.0
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        f.write(yaml_str)
+        path = f.name
+    try:
+        deck = load_deck_from_yaml(path)
+        holder = deck["plate_holder"]
+        nested = holder.contained_labware["plate"]
+        assert isinstance(nested, WellPlate)
+        assert nested.well_depth_mm == pytest.approx(9.5)
     finally:
         Path(path).unlink(missing_ok=True)

--- a/tests/test_deck_loader.py
+++ b/tests/test_deck_loader.py
@@ -1239,3 +1239,92 @@ labware:
                 load_deck_from_yaml(path)
         finally:
             Path(path).unlink(missing_ok=True)
+
+
+# ----- well_depth_mm tests -----
+
+WELL_DEPTH_DECK_YAML = """
+labware:
+  plate_1:
+    type: well_plate
+    name: deep_well_test
+    rows: 8
+    columns: 12
+    height_mm: 14.35
+    well_depth_mm: 10.67
+    calibration:
+      a1: { x: 10.0, y: 10.0, z: 25.9 }
+      a2: { x: 19.0, y: 10.0, z: 25.9 }
+    x_offset_mm: 9.0
+    y_offset_mm: 9.0
+"""
+
+
+def test_well_plate_carries_well_depth_mm_to_plate_object():
+    """The plate definition's inside-floor depth must reach the WellPlate
+    object so analysis pipelines can compute sample thickness from a1.z
+    rather than dragging a manual `well_bottom_z` knob in user configs.
+    """
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        f.write(WELL_DEPTH_DECK_YAML)
+        path = f.name
+    try:
+        deck = load_deck_from_yaml(path)
+        plate = deck["plate_1"]
+        assert plate.well_depth_mm == pytest.approx(10.67)
+        # well floor (where the sample sits) is a1.z minus inside depth.
+        rim_z = plate.get_well_center("A1").z
+        assert rim_z - plate.well_depth_mm == pytest.approx(15.23)
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_well_plate_well_depth_mm_is_optional_default_none():
+    """Existing deck YAMLs that don't declare `well_depth_mm` keep loading."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        f.write(VALID_DECK_ONE_PLATE_ONE_VIAL)
+        path = f.name
+    try:
+        deck = load_deck_from_yaml(path)
+        plate = deck["plate_1"]
+        assert plate.well_depth_mm is None
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_well_plate_well_depth_mm_must_be_positive():
+    """Negative or zero inside depth is nonsensical and should fail validation."""
+    bad_yaml = WELL_DEPTH_DECK_YAML.replace("well_depth_mm: 10.67", "well_depth_mm: -1.0")
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        f.write(bad_yaml)
+        path = f.name
+    try:
+        with pytest.raises(Exception, match="well_depth_mm"):
+            load_deck_from_yaml(path)
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_load_name_sbs_96_wellplate_carries_default_well_depth_mm():
+    """The shipped SBS96 definition supplies a sane default inside depth so
+    `load_name: sbs_96_wellplate` users get it without per-deck overrides.
+    """
+    yaml_str = """
+labware:
+  plate:
+    load_name: sbs_96_wellplate
+    calibration:
+      a1: { x: 10.0, y: 10.0, z: 25.9 }
+      a2: { x: 19.0, y: 10.0, z: 25.9 }
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        f.write(yaml_str)
+        path = f.name
+    try:
+        deck = load_deck_from_yaml(path)
+        plate = deck["plate"]
+        assert plate.well_depth_mm is not None
+        # Standard flat-bottom shallow SBS96 inside depth.
+        assert 9.0 < plate.well_depth_mm < 12.0
+    finally:
+        Path(path).unlink(missing_ok=True)


### PR DESCRIPTION
## Summary

- Outer \`height_mm\` already describes rim → underside-of-plate. The inside well depth (rim → floor where the sample sits) is a different quantity and analysis pipelines need it to compute sample thickness from a contact point.
- Adds \`well_depth_mm\` to \`WellPlateYamlEntry\`, \`NestedWellPlateYamlEntry\`, \`WellPlate\`, and the \`sbs_96_wellplate\` registry definition.
- Backward-compatible: field is Optional with default \`None\`. Existing deck YAMLs without it keep loading.

## Why now

ASMI's analysis path was carrying a manual \`well_bottom_z\` knob in \`analysis.yaml\`, defaulting to \`-85.0\` (positive-down legacy convention). Under the deck-origin +Z-up frame that's silently wrong, and the value should be derivable from \`plate.a1.z - plate.well_depth_mm\` anyway. With this PR, ASMI's follow-up will drop the analysis.yaml knob entirely.

## Why a separate field rather than overloading \`height_mm\`

\`height_mm\` is the outer plate dimension (rim → underside, including skirt). The inside depth diverges by ~3-4 mm because of well-wall thickness and bottom geometry. For SBS96 the outer is ~14.35 mm but the inside flat-bottom depth is ~10.67 mm. Mixing them would silently break either footprint/clearance math or sample-thickness math.

## SBS96 default

\`well_depth_mm: 10.67\` matches standard flat-bottom shallow SBS96 (Corning 3585, Greiner 655180). Deep-well, V-bottom, and round-bottom variants should override at the deck-yaml level until additional registry definitions are added.

## Test plan
- [x] \`pytest tests/test_deck_loader.py -k well_depth\` — 4 new tests pass
- [x] \`pytest tests/\` — 1033/1033 pass
- [ ] **Hardware validation:** none required — this is metadata. ASMI follow-up will exercise the read-from-plate path.

## Hardware impact

None. The new field is metadata; no motion or instrument code reads it yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)