### PR TITLE
Add `asmi` optional-dependency extra (godirect) — mirror the `potenti…

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,9 +152,12 @@ source .venv/bin/activate
 pip install -e ".[dev]"
 ```
 
-Optional per-instrument extras pull in vendor SDKs only when you need them:
+Optional per-instrument extras pull in vendor SDKs only when you need them
+(drivers import these lazily and error clearly if missing):
 
 ```bash
+# ASMI force sensor (Vernier GoDirect)
+pip install -e ".[asmi]"
 # Admiral Instruments SquidStat potentiostat (PySide6 + SquidstatPyLibrary)
 pip install -e ".[potentiostat]"
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,12 @@ dependencies = [
 dev = [
     "pytest",
 ]
+# Per-instrument vendor SDKs — opt in only when you actually use that instrument.
+# The drivers import these lazily and raise a clear error if missing, so the core
+# install (and instruments that don't need them) stays light.
+asmi = [
+    "godirect>=1.0.0",
+]
 potentiostat = [
     "SquidstatPyLibrary",
 ]


### PR DESCRIPTION
…ostat` extra

The ASMI driver imports `godirect` lazily inside `connect()` and raises a clear `ASMIConnectionError("godirect package required: pip install godirect")` if it's missing — so it belongs in an opt-in extra, not the core deps (consistent with how `SquidstatPyLibrary` is the `[potentiostat]` extra). `pip install cubos[asmi]` (or `-e ".[asmi]"`) now pulls `godirect>=1.0.0`. README updated.

Why this surfaced now: ASMI_new's requirements.txt lists `godirect` separately alongside cubos, so its installs always had it; a fresh venv that pulls only `cubos` (e.g. the new polymer-indentation station worker) didn't.