### PR TITLE
[codex] add Ursa Context git hooks and docs guard workflow

### DIFF
--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -u
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+workspace_dir=$(CDPATH= cd -- "$repo_root/.." && pwd)
+context_dir=${URSA_CONTEXT_DIR:-"$workspace_dir/Ursa_Context"}
+guard="$context_dir/tools/ursa_doc_guard.py"
+
+if [ ! -f "$guard" ]; then
+  printf '%s\n' "Ursa_Context warning: doc guard not found: $guard" >&2
+  exit 0
+fi
+
+python3 "$guard" record || {
+  printf '%s\n' "Ursa_Context warning: failed to record commit context." >&2
+  exit 0
+}
+

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -u
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 1
+workspace_dir=$(CDPATH= cd -- "$repo_root/.." && pwd)
+context_dir=${URSA_CONTEXT_DIR:-"$workspace_dir/Ursa_Context"}
+guard="$context_dir/tools/ursa_doc_guard.py"
+
+if [ ! -f "$guard" ]; then
+  printf '%s\n' "Ursa_Context doc guard not found: $guard" >&2
+  printf '%s\n' "Clone Ursa_Context next to this repo or set URSA_CONTEXT_DIR=/path/to/Ursa_Context." >&2
+  printf '%s\n' "For a truly docs-neutral commit, bypass explicitly with URSA_DOC_GUARD_ALLOW_NO_DOCS=1." >&2
+  if [ -n "${URSA_DOC_GUARD_ALLOW_NO_DOCS:-}" ]; then
+    exit 0
+  fi
+  exit 1
+fi
+
+exec python3 "$guard" pre-commit
+

--- a/.github/workflows/ursa-context-doc-guard.yml
+++ b/.github/workflows/ursa-context-doc-guard.yml
@@ -3,6 +3,7 @@ name: Ursa Context Documentation Guard
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  push:
 
 permissions:
   contents: read
@@ -22,8 +23,16 @@ jobs:
         run: |
           set -euo pipefail
 
-          base="${{ github.event.pull_request.base.sha }}"
-          head="${{ github.event.pull_request.head.sha }}"
+          event_name="${{ github.event_name }}"
+          if [ "$event_name" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+            head="${{ github.event.pull_request.head.sha }}"
+          else
+            default_branch="${{ github.event.repository.default_branch }}"
+            git fetch --no-tags origin "$default_branch"
+            base=$(git merge-base "origin/$default_branch" HEAD)
+            head="${{ github.sha }}"
+          fi
           changed_files=$(git diff --name-only --diff-filter=ACMRTD "${base}...${head}")
 
           docs_changed=0
@@ -70,4 +79,3 @@ jobs:
           fi
 
           echo "Documentation guard passed."
-

--- a/.github/workflows/ursa-context-doc-guard.yml
+++ b/.github/workflows/ursa-context-doc-guard.yml
@@ -1,0 +1,73 @@
+name: Ursa Context Documentation Guard
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  docs-guard:
+    name: Require docs for source/config changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check documentation coverage
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          changed_files=$(git diff --name-only --diff-filter=ACMRTD "${base}...${head}")
+
+          docs_changed=0
+          impactful=()
+
+          while IFS= read -r path; do
+            [ -n "$path" ] || continue
+
+            case "$path" in
+              README.md|AGENTS.md|CLAUDE.md|CHANGELOG.md|CONTRIBUTING.md|docs/*|documentation/*|progress/*)
+                docs_changed=1
+                continue
+                ;;
+              .git/*|.mypy_cache/*|.pytest_cache/*|.ruff_cache/*|.venv/*|build/*|dist/*|node_modules/*|coverage/*|htmlcov/*|tests/*|test/*|*/tests/*|*/test/*|package-lock.json|pnpm-lock.yaml|poetry.lock|uv.lock)
+                continue
+                ;;
+            esac
+
+            filename="${path##*/}"
+            ext=""
+            if [[ "$filename" == *.* ]]; then
+              ext=".${filename##*.}"
+            fi
+
+            case "$ext" in
+              .cfg|.cjs|.css|.env|.go|.h|.html|.ini|.js|.json|.jsx|.mjs|.py|.rs|.scad|.sh|.sql|.toml|.ts|.tsx|.yaml|.yml)
+                impactful+=("$path")
+                ;;
+              "")
+                if [[ "$path" != */* ]]; then
+                  impactful+=("$path")
+                fi
+                ;;
+            esac
+          done <<< "$changed_files"
+
+          if (( ${#impactful[@]} > 0 )) && (( docs_changed == 0 )); then
+            echo "::error::Source/config changes require a repo documentation update."
+            printf 'Impactful paths:\n'
+            printf '  - %s\n' "${impactful[@]}"
+            printf '\nAdd or update README.md, AGENTS.md, docs/**, documentation/**, or progress/** in this PR.\n'
+            printf 'This CI check cannot see local Ursa_Context edits; include repo-local docs for remote enforcement.\n'
+            exit 1
+          fi
+
+          echo "Documentation guard passed."
+

--- a/docs/git-hooks.md
+++ b/docs/git-hooks.md
@@ -1,0 +1,32 @@
+# Git Hooks
+
+This repo includes tracked Git hook shims in `.githooks/` for the shared
+`Ursa_Context` documentation guard.
+
+Install them in this checkout:
+
+```bash
+./tools/install-git-hooks.sh
+```
+
+The installer sets `core.hooksPath=.githooks` and makes the hook files
+executable.
+
+The `pre-commit` hook runs `Ursa_Context/tools/ursa_doc_guard.py pre-commit`.
+It blocks source/config commits that do not also include repo documentation or
+durable workspace context updates. The `post-commit` hook records commit
+metadata into `Ursa_Context/inbox/repo-updates.jsonl`.
+
+By default the hooks expect `Ursa_Context` to be cloned next to this repo inside
+the Hephaestus workspace. For another layout, set:
+
+```bash
+export URSA_CONTEXT_DIR=/path/to/Ursa_Context
+```
+
+Bypass the guard only for a deliberately docs-neutral commit:
+
+```bash
+URSA_DOC_GUARD_ALLOW_NO_DOCS=1 git commit
+```
+

--- a/tools/install-git-hooks.sh
+++ b/tools/install-git-hooks.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(git rev-parse --show-toplevel)
+git -C "$repo_root" config core.hooksPath .githooks
+chmod +x "$repo_root/.githooks/pre-commit" "$repo_root/.githooks/post-commit"
+
+workspace_dir=$(CDPATH= cd -- "$repo_root/.." && pwd)
+context_dir=${URSA_CONTEXT_DIR:-"$workspace_dir/Ursa_Context"}
+
+printf '%s\n' "Configured Git hooks for $repo_root"
+printf '%s\n' "core.hooksPath=.githooks"
+if [ ! -f "$context_dir/tools/ursa_doc_guard.py" ]; then
+  printf '%s\n' "Warning: Ursa_Context was not found at $context_dir" >&2
+  printf '%s\n' "Set URSA_CONTEXT_DIR=/path/to/Ursa_Context before committing, or clone it next to this repo." >&2
+fi
+


### PR DESCRIPTION
## Summary

- Add tracked `.githooks` pre-commit and post-commit shims for the shared `Ursa_Context` documentation guard.
- Add `tools/install-git-hooks.sh` to configure `core.hooksPath=.githooks` for local checkouts.
- Add `.github/workflows/ursa-context-doc-guard.yml` so GitHub rejects PRs with source/config changes that lack repo-local documentation updates.
- Document installation, `URSA_CONTEXT_DIR`, commit recording, and the explicit docs-neutral local bypass.

## Local vs Remote Enforcement

- Local hooks call `Ursa_Context/tools/ursa_doc_guard.py` and can also record commits into `Ursa_Context/inbox/repo-updates.jsonl`.
- The GitHub Actions check is self-contained because `Ursa_Context` is private and cannot be assumed available in every repo workflow.
- The remote check enforces repo-local docs (`README.md`, `AGENTS.md`, `docs/**`, `documentation/**`, or `progress/**`) for source/config PR changes.

## Validation

- `sh -n .githooks/pre-commit .githooks/post-commit tools/install-git-hooks.sh`
- Ran `.githooks/pre-commit` with `URSA_CONTEXT_DIR=/Users/alexchan/Documents/hephaestus/Ursa_Context` before committing.
- Locally executed the workflow's embedded shell logic against the branch diff; it passed.