### PR TITLE
Trim duplicated agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,19 +55,6 @@ For setup validation:
 python setup/validate_setup.py <gantry.yaml> <deck.yaml> <protocol.yaml>
 ```
 
-### Instruments
-- `src/instruments/<instrument>/driver.py`, `mock.py`, `models.py`, `exceptions.py`.
-- `src/instruments/registry.yaml`, `src/instruments/yaml_schema.py`.
-- `src/protocol_engine/measurements.py`, `data/data_store.py` — persisted measurements.
-- Tests: `tests/instruments/`, `tests/protocol_engine/`, `tests/data/`.
-
-## Calibration Scripts
-
-- `setup/calibrate_gantry.py` — only supported user-facing calibration entrypoint. Loads input gantry YAML, dispatches single- or multi-instrument flow by instrument count. Without `--output-gantry`, prompts before overwriting input; with it, writes the explicit path without extra prompt.
-- `setup/calibration/single_instrument_calibration.py` — internal one-instrument flow.
-- `setup/calibration/multi_instrument_calibration.py` — internal multi-instrument flow.
-- Detailed operator steps and offset math live in `docs/calibration.md`.
-
 Calibration soft-limit rule: `working_volume` is the usable deck/WPos range
 after homing pull-off. GRBL `$130/$131/$132` and YAML
 `grbl_settings.max_travel_*` are controller spans and must include the `$27`
@@ -76,13 +63,7 @@ writes the per-machine `grbl_settings.homing_pull_off` (`$27`) before homing
 when configured, and saves/programs max travel as usable span plus pull-off.
 Do not treat the pull-off reserve as usable WPos.
 
-## Setup Scripts
-
-- `setup/validate_setup.py` — offline gantry+deck+protocol bounds/semantics validation. PASS/FAIL.
-- `setup/run_protocol.py` — load, validate, connect hardware, run protocol end-to-end. Connects gantry (clearing expected GRBL alarm, restoring state) and instruments before first step; disconnects in `finally`.
-- `setup/hello_world.py` — interactive deck-origin jog test. Homes without rewriting WCS, then jogs in the deck frame. Arrow keys (X/Y ±1mm), Z (down 1mm), X (up 1mm), Q (quit).
-- `setup/keyboard_input.py` — single-keypress reader (Unix `tty`/`termios`).
-`scan.plate` may target either a top-level `WellPlate` key or a nested holder path such as `plate_holder.plate`, as long as that path resolves to a `WellPlate`.
+Detailed calibration, setup, instrument, and test retrieval maps live in `docs/agent-index.md`.
 
 ## Hardware Iteration Mode
 


### PR DESCRIPTION
## Summary\n- Trim duplicated instrument, calibration, and setup retrieval maps from AGENTS.md.\n- Keep the detailed maps in docs/agent-index.md as the durable retrieval source.\n- Preserve hardware safety handoff order, coordinate conventions, and hardware impact reporting requirements.\n\n## Validation\n- wc -l AGENTS.md CLAUDE.md docs/agent-index.md progress/README.md\n  - AGENTS.md: 98 (was 117)\n  - CLAUDE.md: 7\n  - docs/agent-index.md: 75\n  - progress/README.md: 21\n- git diff --check: passed\n- git diff --stat: AGENTS.md | 21 +--------------------\n- mkdocs build --strict: blocked, mkdocs command not installed\n- python3 -m mkdocs build --strict: blocked, No module named mkdocs\n\nCode tests were not run because only instruction docs changed.