### PR TITLE
Add Python-native protocol examples

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -2,6 +2,15 @@
 
 Protocols are ordered YAML step lists that compile into an executable `Protocol` object. At runtime, each step resolves to a registered command handler and executes against a shared `ProtocolContext`.
 
+The same compiled `Protocol` object can also be authored directly in Python:
+
+    from cubos.protocols.asmi import move_a1_protocol
+
+    protocol = move_a1_protocol()
+
+The example modules under `cubos.protocols` mirror representative files in
+`configs/protocol/` while using CubOS imports instead of YAML.
+
 ## Core Flow
 
 1. Load protocol YAML.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ docs = [
 where = ["src", "."]
 include = ["board", "board.*", "data", "data.*", "deck", "deck.*",
            "gantry", "gantry.*", "instruments", "instruments.*",
+           "cubos", "cubos.*",
            "protocol_engine", "protocol_engine.*", "validation", "validation.*"]
 
 [tool.setuptools.package-data]

--- a/src/cubos/__init__.py
+++ b/src/cubos/__init__.py
@@ -1,0 +1,31 @@
+"""Public CubOS Python API."""
+
+from protocol_engine import (
+    Board,
+    CommandRegistry,
+    Protocol,
+    ProtocolContext,
+    ProtocolExecutionError,
+    ProtocolLoaderError,
+    ProtocolStep,
+    load_protocol_from_yaml,
+    load_protocol_from_yaml_safe,
+    protocol_command,
+)
+
+from .protocols import compile_protocol_steps, protocol_step
+
+__all__ = [
+    "Board",
+    "CommandRegistry",
+    "Protocol",
+    "ProtocolContext",
+    "ProtocolExecutionError",
+    "ProtocolLoaderError",
+    "ProtocolStep",
+    "load_protocol_from_yaml",
+    "load_protocol_from_yaml_safe",
+    "protocol_command",
+    "compile_protocol_steps",
+    "protocol_step",
+]

--- a/src/cubos/protocols/__init__.py
+++ b/src/cubos/protocols/__init__.py
@@ -1,0 +1,16 @@
+"""Python-native protocol authoring helpers and example protocols."""
+
+from .asmi import move_a1_protocol
+from .builder import compile_protocol_steps, protocol_step
+from .filmetrics import scan_protocol as filmetrics_scan_protocol
+from .sharc import uv_motion_scan_protocol
+from .sterling import vial_scan_protocol
+
+__all__ = [
+    "compile_protocol_steps",
+    "filmetrics_scan_protocol",
+    "move_a1_protocol",
+    "protocol_step",
+    "uv_motion_scan_protocol",
+    "vial_scan_protocol",
+]

--- a/src/cubos/protocols/asmi.py
+++ b/src/cubos/protocols/asmi.py
@@ -1,0 +1,20 @@
+"""Python-native ASMI protocol definitions."""
+
+from __future__ import annotations
+
+from protocol_engine import Protocol
+
+from .builder import compile_protocol_steps, protocol_step
+
+def move_a1_protocol() -> Protocol:
+    """Return the ASMI A1 move protocol as compiled Python objects."""
+    return Protocol(
+        steps=compile_protocol_steps(
+            protocol_step("home"),
+            protocol_step(
+                "move",
+                instrument="asmi",
+                position="plate.A1",
+            ),
+        ),
+    )

--- a/src/cubos/protocols/builder.py
+++ b/src/cubos/protocols/builder.py
@@ -1,0 +1,43 @@
+"""Helpers for compiling Python protocol definitions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from protocol_engine.protocol import ProtocolStep
+from protocol_engine.registry import CommandRegistry
+
+# Side-effect import: registers built-in commands before registry lookup.
+from protocol_engine import commands as _commands  # noqa: F401
+
+
+def protocol_step(command_name: str, **args: Any) -> ProtocolStep:
+    """Build one validated ProtocolStep from Python keyword arguments.
+
+    This mirrors YAML compilation: the command must be registered and the
+    keyword arguments must satisfy that command's Pydantic schema. The returned
+    step has index 0 so callers can compose steps naturally and let
+    compile_protocol_steps renumber them.
+    """
+    registry = CommandRegistry.instance()
+    registered = registry.get(command_name)
+    validated_args = registered.schema.model_validate(args)
+    return ProtocolStep(
+        index=0,
+        command_name=command_name,
+        handler=registered.handler,
+        args=validated_args.model_dump(exclude_unset=True),
+    )
+
+
+def compile_protocol_steps(*steps: ProtocolStep) -> list[ProtocolStep]:
+    """Return a fresh step list with sequential indexes."""
+    return [
+        ProtocolStep(
+            index=index,
+            command_name=step.command_name,
+            handler=step.handler,
+            args=dict(step.args),
+        )
+        for index, step in enumerate(steps)
+    ]

--- a/src/cubos/protocols/filmetrics.py
+++ b/src/cubos/protocols/filmetrics.py
@@ -1,0 +1,23 @@
+"""Python-native Filmetrics protocol definitions."""
+
+from __future__ import annotations
+
+from protocol_engine import Protocol
+
+from .builder import compile_protocol_steps, protocol_step
+
+
+def scan_protocol() -> Protocol:
+    """Return the Filmetrics scan protocol as compiled Python objects."""
+    return Protocol(
+        steps=compile_protocol_steps(
+            protocol_step(
+                "scan",
+                plate="plate_1",
+                instrument="filmetrics",
+                method="measure",
+                measurement_height=10.0,
+                interwell_scan_height=10.0,
+            ),
+        ),
+    )

--- a/src/cubos/protocols/sharc.py
+++ b/src/cubos/protocols/sharc.py
@@ -1,0 +1,23 @@
+"""Python-native SHARC UV protocol definitions."""
+
+from __future__ import annotations
+
+from protocol_engine import Protocol
+
+from .builder import compile_protocol_steps, protocol_step
+
+
+def uv_motion_scan_protocol() -> Protocol:
+    """Return the SHARC UV motion-only scan protocol as compiled Python objects."""
+    return Protocol(
+        steps=compile_protocol_steps(
+            protocol_step(
+                "scan",
+                plate="plate_holder.plate",
+                instrument="uv_curing",
+                method="health_check",
+                measurement_height=1.0,
+                interwell_scan_height=5.0,
+            ),
+        ),
+    )

--- a/src/cubos/protocols/sterling.py
+++ b/src/cubos/protocols/sterling.py
@@ -1,0 +1,61 @@
+"""Python-native Sterling protocol definitions."""
+
+from __future__ import annotations
+
+from protocol_engine import Protocol
+
+from .builder import compile_protocol_steps, protocol_step
+
+PARK_POSITION = [280.0, 280.0, 85.0]
+VIAL_SCAN_POSITIONS = {
+    "vial_1_scan": [223.0, 25.0, 40.0],
+    "vial_2_scan": [223.0, 58.5, 40.0],
+    "vial_3_scan": [223.0, 92.0, 40.0],
+    "vial_4_scan": [223.0, 125.5, 40.0],
+    "vial_5_scan": [223.0, 159.0, 40.0],
+    "vial_6_scan": [223.0, 192.5, 40.0],
+    "vial_7_scan": [223.0, 226.0, 40.0],
+    "vial_8_scan": [223.0, 259.5, 40.0],
+}
+VIAL_SCAN_ORDER = (
+    "vial_1_scan",
+    "vial_8_scan",
+    "vial_2_scan",
+    "vial_7_scan",
+    "vial_3_scan",
+    "vial_6_scan",
+    "vial_4_scan",
+    "vial_5_scan",
+)
+
+
+def vial_scan_protocol() -> Protocol:
+    """Return the Sterling vial-position scan as compiled Python objects."""
+    return Protocol(
+        steps=compile_protocol_steps(
+            protocol_step("home"),
+            protocol_step(
+                "move",
+                instrument="potentiostat",
+                position="park_position",
+                travel_z=85.0,
+            ),
+            *[
+                protocol_step(
+                    "move",
+                    instrument="potentiostat",
+                    position=position,
+                    travel_z=85.0,
+                )
+                for position in VIAL_SCAN_ORDER
+            ],
+            protocol_step(
+                "move",
+                instrument="potentiostat",
+                position="park_position",
+                travel_z=85.0,
+            ),
+            protocol_step("home"),
+        ),
+        positions={"park_position": PARK_POSITION, **VIAL_SCAN_POSITIONS},
+    )

--- a/tests/cubos/test_pythonic_protocols.py
+++ b/tests/cubos/test_pythonic_protocols.py
@@ -1,0 +1,56 @@
+import cubos
+from cubos.protocols import filmetrics_scan_protocol
+from cubos.protocols import move_a1_protocol as exported_move_a1_protocol
+from cubos.protocols.asmi import move_a1_protocol
+from cubos.protocols.sharc import uv_motion_scan_protocol
+from cubos.protocols.sterling import vial_scan_protocol
+from protocol_engine.loader import load_protocol_from_yaml
+
+
+def _protocol_signature(protocol):
+    return (
+        protocol.positions,
+        [(step.index, step.command_name, step.args) for step in protocol.steps],
+    )
+
+
+def test_asmi_move_a1_python_protocol_matches_yaml():
+    yaml_protocol = load_protocol_from_yaml("configs/protocol/asmi_move_a1.yaml")
+
+    assert _protocol_signature(move_a1_protocol()) == _protocol_signature(
+        yaml_protocol
+    )
+    assert _protocol_signature(exported_move_a1_protocol()) == _protocol_signature(
+        yaml_protocol
+    )
+
+
+def test_cubos_package_exports_protocol_builder():
+    step = cubos.protocol_step("home")
+
+    assert step.command_name == "home"
+    assert step.args == {}
+
+
+def test_filmetrics_scan_python_protocol_matches_yaml():
+    yaml_protocol = load_protocol_from_yaml("configs/protocol/filmetrics_scan.yaml")
+
+    assert _protocol_signature(filmetrics_scan_protocol()) == _protocol_signature(
+        yaml_protocol
+    )
+
+
+def test_sharc_uv_motion_scan_python_protocol_matches_yaml():
+    yaml_protocol = load_protocol_from_yaml("configs/protocol/sharc_uv_motion_scan.yaml")
+
+    assert _protocol_signature(uv_motion_scan_protocol()) == _protocol_signature(
+        yaml_protocol
+    )
+
+
+def test_sterling_vial_scan_python_protocol_matches_yaml():
+    yaml_protocol = load_protocol_from_yaml("configs/protocol/sterling_vial_scan.yaml")
+
+    assert _protocol_signature(vial_scan_protocol()) == _protocol_signature(
+        yaml_protocol
+    )


### PR DESCRIPTION
## Summary
- add a public `cubos` package facade with a validated `protocol_step()` helper for Python-native protocol authoring
- port four existing YAML protocols into `cubos.protocols`: ASMI A1 move, Filmetrics scan, SHARC UV motion scan, and Sterling vial scan
- add equivalence tests that compare Python-authored protocols to the existing YAML loader output

## Validation
- `.venv/bin/python -m pytest tests/cubos/test_pythonic_protocols.py tests/protocol_engine -q` -> 270 passed
- Python protocol offline semantic/bounds validation:
  - asmi_move_a1: semantic=0 bounds=0 steps=2
  - filmetrics: semantic=0 bounds=0 steps=1
  - sharc_uv_motion: semantic=0 bounds=0 steps=1
  - sterling_vial: semantic=0 bounds=0 steps=12
- `.venv/bin/python -m pytest -q` -> 1266 passed, 15 skipped, 10 subtests passed
- `git diff --check` -> clean

## Hardware
- Potentially affected: protocol authoring surface only; no existing YAML/config motion path changed.
- Offline validation only; no physical hardware validation performed.
