### PR TITLE
[codex] Add ASMI raw CSV export

### DIFF
--- a/data/asmi_raw_csv.py
+++ b/data/asmi_raw_csv.py
@@ -1,0 +1,182 @@
+"""Export ASMI indentation measurements as ASMI_new-compatible raw CSV files."""
+
+from __future__ import annotations
+
+import csv
+import json
+import re
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+
+def export_asmi_raw_csvs(
+    *,
+    db_path: str,
+    campaign_id: int,
+    output_dir: str | Path,
+) -> list[Path]:
+    """Export ASMI measurements for a campaign as per-well raw CSV files.
+
+    The output layout matches the raw measurement files consumed by
+    ``projects/ASMI_new``: metadata rows, a blank separator, then sample rows
+    with ``Timestamp(s), Z_Position(mm), Raw_Force(N), Corrected_Force(N)`` and
+    an optional ``Direction`` column.
+    """
+    destination = Path(output_dir)
+    destination.mkdir(parents=True, exist_ok=True)
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            """
+            SELECT
+                m.id AS measurement_id,
+                m.sample_timestamps,
+                m.z_positions,
+                m.raw_forces,
+                m.corrected_forces,
+                m.directions,
+                m.baseline_avg,
+                m.baseline_std,
+                m.force_exceeded,
+                m.data_points,
+                m.step_size_mm,
+                m.z_target_mm,
+                m.force_limit_n,
+                m.timestamp,
+                e.well_id
+            FROM asmi_measurements m
+            JOIN experiments e ON e.id = m.experiment_id
+            WHERE e.campaign_id = ?
+            ORDER BY m.id
+            """,
+            (campaign_id,),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    written: list[Path] = []
+    for row in rows:
+        path = destination / _filename_for_row(row)
+        _write_asmi_new_csv(row, path)
+        written.append(path)
+    return written
+
+
+def _write_asmi_new_csv(row: sqlite3.Row, path: Path) -> None:
+    z_positions = _json_array(row["z_positions"], "z_positions")
+    raw_forces = _json_array(row["raw_forces"], "raw_forces")
+    corrected_forces = _json_array(row["corrected_forces"], "corrected_forces")
+    timestamps = _json_array_or_default(
+        row["sample_timestamps"],
+        "sample_timestamps",
+        default=[None] * len(z_positions),
+    )
+    directions = _json_array_or_default(
+        row["directions"],
+        "directions",
+        default=[None] * len(z_positions),
+    )
+    _validate_equal_lengths(
+        z_positions=z_positions,
+        raw_forces=raw_forces,
+        corrected_forces=corrected_forces,
+        sample_timestamps=timestamps,
+        directions=directions,
+    )
+
+    has_directions = any(direction not in (None, "") for direction in directions)
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["Test_Time", row["timestamp"]])
+        writer.writerow(["Well", row["well_id"] or ""])
+        writer.writerow(["Target_Z(mm)", _format_optional(row["z_target_mm"], 3)])
+        writer.writerow(["Step_Size(mm)", _format_optional(row["step_size_mm"], 3)])
+        writer.writerow(["Force_Limit(N)", _format_optional(row["force_limit_n"], 1)])
+        writer.writerow(["Baseline_Force(N)", _format_optional(row["baseline_avg"], 3)])
+        writer.writerow(["Baseline_Std(N)", _format_optional(row["baseline_std"], 3)])
+        writer.writerow(["Force_Exceeded", str(bool(row["force_exceeded"]))])
+        writer.writerow([])
+        header = [
+            "Timestamp(s)",
+            "Z_Position(mm)",
+            "Raw_Force(N)",
+            "Corrected_Force(N)",
+        ]
+        if has_directions:
+            header.append("Direction")
+        writer.writerow(header)
+
+        for timestamp, z_pos, raw_force, corrected_force, direction in zip(
+            timestamps,
+            z_positions,
+            raw_forces,
+            corrected_forces,
+            directions,
+        ):
+            sample_row = [
+                _format_optional(timestamp, 3),
+                _format_optional(z_pos, 3),
+                _format_optional(raw_force, 3),
+                _format_optional(corrected_force, 3),
+            ]
+            if has_directions:
+                sample_row.append("" if direction is None else str(direction))
+            writer.writerow(sample_row)
+
+
+def _filename_for_row(row: sqlite3.Row) -> str:
+    well = row["well_id"] or f"measurement_{row['measurement_id']}"
+    timestamp = _timestamp_suffix(str(row["timestamp"]))
+    return f"well_{well}_{timestamp}.csv"
+
+
+def _timestamp_suffix(timestamp: str) -> str:
+    match = re.match(
+        r"(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2}):(\d{2})",
+        timestamp,
+    )
+    if match is None:
+        safe = re.sub(r"[^0-9A-Za-z]+", "_", timestamp).strip("_")
+        return safe or "unknown_time"
+    return "".join(match.groups()[:3]) + "_" + "".join(match.groups()[3:])
+
+
+def _json_array(value: Any, field_name: str) -> list[Any]:
+    if value is None:
+        raise ValueError(f"ASMI field '{field_name}' is missing")
+    parsed = json.loads(value) if isinstance(value, str) else value
+    if not isinstance(parsed, list):
+        raise ValueError(f"ASMI field '{field_name}' must be a JSON array")
+    return parsed
+
+
+def _json_array_or_default(
+    value: Any,
+    field_name: str,
+    *,
+    default: list[Any],
+) -> list[Any]:
+    if value is None:
+        return list(default)
+    return _json_array(value, field_name)
+
+
+def _validate_equal_lengths(**arrays: list[Any]) -> None:
+    lengths = {name: len(value) for name, value in arrays.items()}
+    expected = next(iter(lengths.values()), 0)
+    mismatches = {
+        name: length for name, length in lengths.items()
+        if length != expected
+    }
+    if mismatches:
+        details = ", ".join(f"{name}={length}" for name, length in lengths.items())
+        raise ValueError(f"ASMI measurement arrays must have equal lengths: {details}")
+
+
+def _format_optional(value: Any, digits: int) -> str:
+    if value is None:
+        return ""
+    return f"{float(value):.{digits}f}"

--- a/data/data_store.py
+++ b/data/data_store.py
@@ -59,9 +59,11 @@ CREATE TABLE IF NOT EXISTS camera_measurements (
 CREATE TABLE IF NOT EXISTS asmi_measurements (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
     experiment_id   INTEGER NOT NULL REFERENCES experiments(id),
+    sample_timestamps TEXT,
     z_positions     TEXT    NOT NULL,
     raw_forces      TEXT    NOT NULL,
     corrected_forces TEXT   NOT NULL,
+    directions       TEXT,
     baseline_avg    REAL    NOT NULL,
     baseline_std    REAL    NOT NULL,
     force_exceeded  INTEGER NOT NULL DEFAULT 0,
@@ -123,11 +125,34 @@ class DataStore:
 
     def _create_tables(self) -> None:
         self._conn.executescript(_SCHEMA_SQL)
+        self._ensure_asmi_optional_columns()
 
     _BLOB_COLUMNS = {
         "uvvis_measurements": ("wavelengths", "intensities"),
-        "asmi_measurements": ("z_positions", "raw_forces", "corrected_forces"),
+        "asmi_measurements": (
+            "sample_timestamps",
+            "z_positions",
+            "raw_forces",
+            "corrected_forces",
+            "directions",
+        ),
     }
+
+    def _ensure_asmi_optional_columns(self) -> None:
+        """Add ASMI raw-export columns for databases created before this feature."""
+        columns = {
+            row[1] for row in self._conn.execute("PRAGMA table_info(asmi_measurements)")
+        }
+        additions = {
+            "sample_timestamps": "TEXT",
+            "directions": "TEXT",
+        }
+        for name, column_type in additions.items():
+            if name not in columns:
+                self._conn.execute(
+                    f"ALTER TABLE asmi_measurements ADD COLUMN {name} {column_type}"
+                )
+        self._conn.commit()
 
     def _check_schema_migration(self) -> None:
         """Raise if any float-array column still contains binary BLOB data."""
@@ -229,13 +254,26 @@ class DataStore:
         if measurement.measurement_type == MeasurementType.ASMI_INDENTATION:
             return self._log_asmi(
                 experiment_id=experiment_id,
+                sample_timestamps=(
+                    tuple(measurement.payload["timestamps_s"])
+                    if "timestamps_s" in measurement.payload
+                    else None
+                ),
                 z_positions=tuple(measurement.payload["z_positions_mm"]),
                 raw_forces=tuple(measurement.payload["raw_forces_n"]),
                 corrected_forces=tuple(measurement.payload["corrected_forces_n"]),
+                directions=(
+                    tuple(measurement.payload["directions"])
+                    if "directions" in measurement.payload
+                    else None
+                ),
                 baseline_avg=float(measurement.metadata["baseline_avg"]),
                 baseline_std=float(measurement.metadata["baseline_std"]),
                 force_exceeded=bool(measurement.metadata["force_exceeded"]),
                 data_points=int(measurement.metadata["data_points"]),
+                step_size_mm=measurement.metadata.get("step_size_mm"),
+                z_target_mm=measurement.metadata.get("z_target_mm"),
+                force_limit_n=measurement.metadata.get("force_limit_n"),
             )
 
         if measurement.measurement_type in {
@@ -318,28 +356,43 @@ class DataStore:
     def _log_asmi(
         self,
         experiment_id: int,
+        sample_timestamps: Optional[tuple[float | None, ...]],
         z_positions: tuple[float, ...],
         raw_forces: tuple[float, ...],
         corrected_forces: tuple[float, ...],
+        directions: Optional[tuple[str, ...]],
         baseline_avg: float,
         baseline_std: float,
         force_exceeded: bool,
         data_points: int,
+        step_size_mm: Optional[float] = None,
+        z_target_mm: Optional[float] = None,
+        force_limit_n: Optional[float] = None,
     ) -> int:
         cursor = self._conn.execute(
             "INSERT INTO asmi_measurements "
-            "(experiment_id, z_positions, raw_forces, corrected_forces, "
-            "baseline_avg, baseline_std, force_exceeded, data_points) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            "(experiment_id, sample_timestamps, z_positions, raw_forces, "
+            "corrected_forces, directions, baseline_avg, baseline_std, "
+            "force_exceeded, data_points, step_size_mm, z_target_mm, force_limit_n) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 experiment_id,
+                (
+                    json.dumps(list(sample_timestamps))
+                    if sample_timestamps is not None
+                    else None
+                ),
                 json.dumps(list(z_positions)),
                 json.dumps(list(raw_forces)),
                 json.dumps(list(corrected_forces)),
+                json.dumps(list(directions)) if directions is not None else None,
                 baseline_avg,
                 baseline_std,
                 int(force_exceeded),
                 data_points,
+                step_size_mm,
+                z_target_mm,
+                force_limit_n,
             ),
         )
         self._conn.commit()

--- a/data/export_helpers.py
+++ b/data/export_helpers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
+from data.asmi_raw_csv import export_asmi_raw_csvs
 from data.data_reader import DataReader
 
 
@@ -44,12 +45,32 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Instrument name: uvvis, filmetrics, camera, asmi",
     )
     instrument_parser.add_argument("--csv", help="Optional output CSV path.")
+
+    asmi_raw_parser = subparsers.add_parser(
+        "asmi-raw-csv",
+        help="Export ASMI campaign measurements as ASMI_new raw per-well CSVs.",
+    )
+    asmi_raw_parser.add_argument("campaign_id", type=int)
+    asmi_raw_parser.add_argument("output_dir")
     return parser
 
 
 def main() -> int:
     parser = _build_parser()
     args = parser.parse_args()
+
+    if args.command == "asmi-raw-csv":
+        written = export_asmi_raw_csvs(
+            db_path=args.db_path,
+            campaign_id=args.campaign_id,
+            output_dir=args.output_dir,
+        )
+        if not written:
+            print("No rows found.")
+            return 0
+        for path in written:
+            print(f"Wrote CSV: {Path(path).resolve()}")
+        return 0
 
     with DataReader(db_path=args.db_path) as reader:
         if args.command == "campaign-experiments":

--- a/docs/data.md
+++ b/docs/data.md
@@ -25,3 +25,19 @@ When `ProtocolContext.data_store` and `ProtocolContext.campaign_id` are set, pro
 
 - `data.data_store` — database creation and write API
 - `data.data_reader` — read and query helpers
+- `data.export_helpers` — CLI helpers for exporting stored data to CSV
+
+## ASMI Raw CSV Export
+
+Use `asmi-raw-csv` to export stored ASMI indentation measurements in the raw
+per-well CSV format consumed by `projects/ASMI_new`:
+
+```bash
+PYTHONPATH=. python -m data.export_helpers \
+  --db-path data/databases/panda_data.db \
+  asmi-raw-csv <campaign_id> results/measurements/<run_folder>
+```
+
+Each ASMI measurement becomes a `well_<well>_<timestamp>.csv` file with
+metadata rows followed by `Timestamp(s)`, `Z_Position(mm)`, `Raw_Force(N)`,
+`Corrected_Force(N)`, and `Direction` when direction data is available.

--- a/src/protocol_engine/measurements.py
+++ b/src/protocol_engine/measurements.py
@@ -144,6 +144,7 @@ def normalize_measurement(
                 "defaulting missing entries to 'down'",
             )
         payload = {
+            "timestamps_s": [s.get("timestamp") for s in steps],
             "z_positions_mm": [s["z_mm"] for s in steps],
             "raw_forces_n": [s["raw_force_n"] for s in steps],
             "corrected_forces_n": [s["corrected_force_n"] for s in steps],

--- a/tests/data/test_asmi_raw_csv_export.py
+++ b/tests/data/test_asmi_raw_csv_export.py
@@ -1,0 +1,88 @@
+"""Tests for ASMI raw per-well CSV export."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from data.asmi_raw_csv import export_asmi_raw_csvs
+from data.data_store import DataStore
+from protocol_engine.measurements import InstrumentMeasurement, MeasurementType
+
+
+def _seed_asmi_measurement(db_path: Path) -> int:
+    store = DataStore(db_path=str(db_path))
+    campaign_id = store.create_campaign(description="asmi raw csv export")
+    experiment_id = store.create_experiment(
+        campaign_id,
+        labware_name="asmi_96_well_deck_origin",
+        well_id="A1",
+        contents_json="[]",
+    )
+    store.log_measurement(
+        experiment_id,
+        InstrumentMeasurement(
+            measurement_type=MeasurementType.ASMI_INDENTATION,
+            payload={
+                "timestamps_s": [1761841220.199, 1761841220.327],
+                "z_positions_mm": [-74.01, -74.02],
+                "raw_forces_n": [0.463, 0.457],
+                "corrected_forces_n": [0.004, -0.002],
+                "directions": ["down", "up"],
+            },
+            metadata={
+                "baseline_avg": 0.459,
+                "baseline_std": 0.003,
+                "force_exceeded": True,
+                "data_points": 2,
+                "step_size_mm": 0.01,
+                "z_target_mm": -80.0,
+                "force_limit_n": 10.0,
+            },
+        ),
+    )
+    store._conn.execute(
+        "UPDATE asmi_measurements SET timestamp = ?",
+        ("2025-10-30 12:21:07",),
+    )
+    store._conn.commit()
+    store.close()
+    return campaign_id
+
+
+def test_exports_asmi_new_raw_per_well_csv_from_datastore(tmp_path: Path):
+    db_path = tmp_path / "asmi.db"
+    campaign_id = _seed_asmi_measurement(db_path)
+    output_dir = tmp_path / "measurements"
+
+    written = export_asmi_raw_csvs(
+        db_path=str(db_path),
+        campaign_id=campaign_id,
+        output_dir=output_dir,
+    )
+
+    assert written == [output_dir / "well_A1_20251030_122107.csv"]
+
+    with written[0].open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.reader(handle))
+
+    assert rows == [
+        ["Test_Time", "2025-10-30 12:21:07"],
+        ["Well", "A1"],
+        ["Target_Z(mm)", "-80.000"],
+        ["Step_Size(mm)", "0.010"],
+        ["Force_Limit(N)", "10.0"],
+        ["Baseline_Force(N)", "0.459"],
+        ["Baseline_Std(N)", "0.003"],
+        ["Force_Exceeded", "True"],
+        [],
+        [
+            "Timestamp(s)",
+            "Z_Position(mm)",
+            "Raw_Force(N)",
+            "Corrected_Force(N)",
+            "Direction",
+        ],
+        ["1761841220.199", "-74.010", "0.463", "0.004", "down"],
+        ["1761841220.327", "-74.020", "0.457", "-0.002", "up"],
+    ]

--- a/tests/data/test_data_store.py
+++ b/tests/data/test_data_store.py
@@ -367,9 +367,11 @@ class TestASMIInstrumentMeasurementLogging:
         measurement = InstrumentMeasurement(
             measurement_type=MeasurementType.ASMI_INDENTATION,
             payload={
+                "timestamps_s": [1761841220.199, 1761841220.327, 1761841220.453],
                 "z_positions_mm": [0.0, 0.1, 0.2],
                 "raw_forces_n": [0.01, 0.02, 0.03],
                 "corrected_forces_n": [0.005, 0.015, 0.025],
+                "directions": ["down", "down", "up"],
             },
             metadata={
                 "baseline_avg": 0.005,
@@ -381,13 +383,16 @@ class TestASMIInstrumentMeasurementLogging:
         mid = store.log_measurement(eid, measurement)
 
         row = store._conn.execute(
-            "SELECT z_positions, raw_forces, corrected_forces FROM asmi_measurements WHERE id = ?",
+            "SELECT sample_timestamps, z_positions, raw_forces, "
+            "corrected_forces, directions FROM asmi_measurements WHERE id = ?",
             (mid,),
         ).fetchone()
 
-        assert json.loads(row[0]) == [0.0, 0.1, 0.2]
-        assert json.loads(row[1]) == [0.01, 0.02, 0.03]
-        assert json.loads(row[2]) == [0.005, 0.015, 0.025]
+        assert json.loads(row[0]) == [1761841220.199, 1761841220.327, 1761841220.453]
+        assert json.loads(row[1]) == [0.0, 0.1, 0.2]
+        assert json.loads(row[2]) == [0.01, 0.02, 0.03]
+        assert json.loads(row[3]) == [0.005, 0.015, 0.025]
+        assert json.loads(row[4]) == ["down", "down", "up"]
         store.close()
 
 

--- a/tests/data/test_export_helpers.py
+++ b/tests/data/test_export_helpers.py
@@ -33,6 +33,40 @@ def _seed_db(path: str) -> None:
     store.close()
 
 
+def _seed_asmi_db(path: str) -> None:
+    store = DataStore(db_path=path)
+    cid = store.create_campaign(description="asmi export test")
+    eid = store.create_experiment(cid, "plate_1", "A1", "[]")
+    store.log_measurement(
+        eid,
+        InstrumentMeasurement(
+            measurement_type=MeasurementType.ASMI_INDENTATION,
+            payload={
+                "timestamps_s": [1761841220.199],
+                "z_positions_mm": [-74.01],
+                "raw_forces_n": [0.463],
+                "corrected_forces_n": [0.004],
+                "directions": ["down"],
+            },
+            metadata={
+                "baseline_avg": 0.459,
+                "baseline_std": 0.003,
+                "force_exceeded": False,
+                "data_points": 1,
+                "step_size_mm": 0.01,
+                "z_target_mm": -80.0,
+                "force_limit_n": 10.0,
+            },
+        ),
+    )
+    store._conn.execute(
+        "UPDATE asmi_measurements SET timestamp = ?",
+        ("2025-10-30 12:21:07",),
+    )
+    store._conn.commit()
+    store.close()
+
+
 # ─── campaign-experiments subcommand ─────────────────────────────────────────
 
 
@@ -131,3 +165,23 @@ class TestExperimentInstrumentSubcommand:
         result = main()
         assert result == 0
         assert "No rows found" in capsys.readouterr().out
+
+
+class TestASMIRawCSVSubcommand:
+
+    def test_writes_asmi_new_raw_csvs(self, tmp_path, capsys, monkeypatch):
+        db = str(tmp_path / "test.db")
+        out_dir = tmp_path / "measurements"
+        _seed_asmi_db(db)
+        monkeypatch.setattr(
+            sys, "argv",
+            ["export", "--db-path", db, "asmi-raw-csv", "1", str(out_dir)],
+        )
+
+        result = main()
+
+        assert result == 0
+        assert "Wrote CSV:" in capsys.readouterr().out
+        output = out_dir / "well_A1_20251030_122107.csv"
+        assert output.exists()
+        assert "Timestamp(s),Z_Position(mm),Raw_Force(N)" in output.read_text()

--- a/tests/protocol_engine/test_measurements.py
+++ b/tests/protocol_engine/test_measurements.py
@@ -87,9 +87,27 @@ class TestNormalizeMeasurement:
     def test_normalize_asmi_indentation_with_return_mode(self):
         raw_result = {
             "measurements": [
-                {"z_mm": -73.01, "raw_force_n": 0.10, "corrected_force_n": 0.01, "direction": "down"},
-                {"z_mm": -73.02, "raw_force_n": 0.11, "corrected_force_n": 0.02, "direction": "down"},
-                {"z_mm": -73.01, "raw_force_n": 0.09, "corrected_force_n": 0.00, "direction": "up"},
+                {
+                    "timestamp": 1761841220.199,
+                    "z_mm": -73.01,
+                    "raw_force_n": 0.10,
+                    "corrected_force_n": 0.01,
+                    "direction": "down",
+                },
+                {
+                    "timestamp": 1761841220.327,
+                    "z_mm": -73.02,
+                    "raw_force_n": 0.11,
+                    "corrected_force_n": 0.02,
+                    "direction": "down",
+                },
+                {
+                    "timestamp": 1761841220.453,
+                    "z_mm": -73.01,
+                    "raw_force_n": 0.09,
+                    "corrected_force_n": 0.00,
+                    "direction": "up",
+                },
             ],
             "baseline_avg": 0.09,
             "baseline_std": 0.001,
@@ -105,6 +123,11 @@ class TestNormalizeMeasurement:
         )
 
         assert measurement.measurement_type == MeasurementType.ASMI_INDENTATION
+        assert measurement.payload["timestamps_s"] == [
+            1761841220.199,
+            1761841220.327,
+            1761841220.453,
+        ]
         assert measurement.payload["directions"] == ["down", "down", "up"]
         assert measurement.metadata["measure_with_return"] is True
 


### PR DESCRIPTION
## Summary

Adds an ASMI-specific raw CSV export path that writes CubOS-stored ASMI indentation data in the per-well format consumed by `projects/ASMI_new`.

## Changes

- Add `data.asmi_raw_csv.export_asmi_raw_csvs` to export one `well_<well>_<timestamp>.csv` file per ASMI measurement.
- Add `data.export_helpers asmi-raw-csv <campaign_id> <output_dir>` CLI support.
- Preserve ASMI sample timestamps and directions through measurement normalization and SQLite storage.
- Document the new ASMI raw CSV export command.
- Add datastore, CLI, and exact CSV output tests using mock SQLite data.

## Validation

- `python -m pytest tests/data/test_asmi_raw_csv_export.py -q`
- `python -m pytest tests/data tests/protocol_engine/test_measurements.py -q`
- `git diff --check -- data/asmi_raw_csv.py data/data_store.py data/export_helpers.py docs/data.md src/protocol_engine/measurements.py tests/data/test_asmi_raw_csv_export.py tests/data/test_data_store.py tests/data/test_export_helpers.py tests/protocol_engine/test_measurements.py`

## Notes

This PR intentionally excludes unrelated calibration edits currently present in the local worktree.

## TODO

- [ ] Consider adding ASMI retry-on-precontact support equivalent to `remeasure_if_first_force_above` from `projects/ASMI_new`.
- [ ] Consider adding the ASMI retry height margin equivalent to `well_top_z_remargin_offset` from `projects/ASMI_new`.
