### PR TITLE
Remove gantry homing strategy config

### DIFF
--- a/configs/gantry/cub_filmetrics.yaml
+++ b/configs/gantry/cub_filmetrics.yaml
@@ -9,7 +9,6 @@ serial_port: /dev/ttyUSB0
 gantry_type: cub
 
 cnc:
-  homing_strategy: standard
   factory_z_travel_mm: 90.0
   y_axis_motion: head
   # Absolute deck-frame Z used for inter-labware travel and the entry

--- a/configs/gantry/cub_raman.yaml
+++ b/configs/gantry/cub_raman.yaml
@@ -1,7 +1,6 @@
 serial_port: /dev/ttyUSB0
 gantry_type: cub
 cnc:
-  homing_strategy: standard
   factory_z_travel_mm: 105.0
   y_axis_motion: head
   safe_z: 80.0

--- a/configs/gantry/cub_sharc.yaml
+++ b/configs/gantry/cub_sharc.yaml
@@ -1,7 +1,6 @@
 serial_port: /dev/ttyUSB0
 gantry_type: cub
 cnc:
-  homing_strategy: standard
   factory_z_travel_mm: 101.5
   y_axis_motion: head
   safe_z: 101.5

--- a/configs/gantry/cub_xl_asmi.yaml
+++ b/configs/gantry/cub_xl_asmi.yaml
@@ -1,7 +1,6 @@
 serial_port: /dev/ttyUSB0
 gantry_type: cub_xl
 cnc:
-  homing_strategy: standard
   factory_z_travel_mm: 110.0
   calibration_block_height_mm: 35.0
   y_axis_motion: head

--- a/configs/gantry/cub_xl_panda.yaml
+++ b/configs/gantry/cub_xl_panda.yaml
@@ -10,7 +10,6 @@ serial_port: /dev/ttyUSB0
 gantry_type: cub_xl
 
 cnc:
-  homing_strategy: standard
   factory_z_travel_mm: 100.0
   y_axis_motion: head
   # Absolute deck-frame Z used for inter-labware travel and the entry

--- a/configs/gantry/cub_xl_sterling.yaml
+++ b/configs/gantry/cub_xl_sterling.yaml
@@ -1,7 +1,6 @@
 serial_port: /dev/ttyUSB0
 gantry_type: cub_xl
 cnc:
-  homing_strategy: standard
   factory_z_travel_mm: 129.0
   y_axis_motion: head
   # Absolute deck-frame Z used for inter-labware travel and the entry

--- a/configs/gantry/cub_xl_sterling_3_instrument.yaml
+++ b/configs/gantry/cub_xl_sterling_3_instrument.yaml
@@ -1,7 +1,6 @@
 serial_port: /dev/ttyUSB0
 gantry_type: cub_xl
 cnc:
-  homing_strategy: standard
   factory_z_travel_mm: 104.0
   y_axis_motion: head
   safe_z: 85.0

--- a/configs/sim/pipette_tip_transfer/gantry.yaml
+++ b/configs/sim/pipette_tip_transfer/gantry.yaml
@@ -9,7 +9,6 @@
 serial_port: /dev/null
 gantry_type: cub_xl
 cnc:
-  homing_strategy: standard
   factory_z_travel_mm: 129.0
   y_axis_motion: head
   safe_z: 69.0

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,7 +29,6 @@ Gantry YAML describes the machine and mounted instruments.
 serial_port: /dev/ttyUSB0
 gantry_type: cub_xl
 cnc:
-  homing_strategy: standard
   factory_z_travel_mm: 110.0
   calibration_block_height_mm: 35.0
   y_axis_motion: head

--- a/docs/gantry.md
+++ b/docs/gantry.md
@@ -34,7 +34,6 @@ Representative example:
 serial_port: /dev/ttyUSB0
 gantry_type: cub_xl
 cnc:
-  homing_strategy: standard
   factory_z_travel_mm: 87.0
   y_axis_motion: head
   # Absolute deck-frame Z used for inter-labware travel and the entry
@@ -81,7 +80,7 @@ Use this file when:
 `gantry_type` is required at the gantry YAML root and identifies the physical
 machine family. Supported values are `cub` and `cub_xl`.
 
-`homing_strategy` must be `standard`, which runs GRBL `$H`.
+Homing uses the standard GRBL `$H` command.
 
 `factory_z_travel_mm` is required and must be greater than zero. It is the
 out-of-box vertical travel range for the gantry family/workcell and is not

--- a/progress/2026-06-12-remove-gantry-homing-strategy.md
+++ b/progress/2026-06-12-remove-gantry-homing-strategy.md
@@ -1,0 +1,14 @@
+# Remove gantry homing_strategy
+
+Issue: Ursa-Laboratories/CubOS#182
+
+## Changed
+- Removed `cnc.homing_strategy` from gantry YAML configs, fixtures, docs, and examples.
+- Removed the `HomingStrategy` domain enum and `GantryConfig.homing_strategy` field.
+- Kept gantry homing behavior on the standard GRBL `$H` command; homing is no longer configurable through gantry CNC YAML.
+- Updated schema/tests so `homing_strategy` is now rejected as an unknown CNC key.
+
+## Verification
+- Focused tests: `139 passed, 6 subtests passed in 0.83s`.
+- Full tests: `1255 passed, 17 skipped, 10 subtests passed in 7.54s`.
+- `git diff --check`: passed.

--- a/src/gantry/__init__.py
+++ b/src/gantry/__init__.py
@@ -12,7 +12,6 @@ from .gantry import Gantry
 from .gantry_config import (
     GantryConfig,
     GantryType,
-    HomingStrategy,
     WorkingVolume,
 )
 from .instrument_loader import (
@@ -43,7 +42,6 @@ __all__ = [
     "GantryLoaderError",
     "GantryType",
     "FixedStructureBox",
-    "HomingStrategy",
     "LocationNotFound",
     "MillConnectionError",
     "LimitRecoveryResult",

--- a/src/gantry/gantry.py
+++ b/src/gantry/gantry.py
@@ -138,16 +138,12 @@ class Gantry:
             return False
 
     def home(self) -> None:
-        """Home the gantry using the configured homing strategy."""
+        """Home the gantry with the standard GRBL homing command."""
         if self._offline:
             return
         assert self._mill is not None
-        strategy = self._homing_strategy()
         try:
-            if strategy == "standard":
-                self._mill.home()
-            else:
-                raise ValueError(f"Unknown homing strategy: {strategy!r}")
+            self._mill.home()
         except (MillConnectionError, StatusReturnError) as exc:
             self.logger.error("Error homing gantry: %s", exc)
             raise
@@ -777,17 +773,6 @@ class Gantry:
             "homing_pull_off_mm": homing_pull_off_mm,
             "position": final_position,
         }
-
-    def _homing_strategy(self) -> str:
-        """Extract the configured homing strategy from dict or dataclass config."""
-        if isinstance(self.config, dict):
-            cnc = self.config.get("cnc", {})
-            if isinstance(cnc, dict):
-                return cnc.get("homing_strategy", "standard")
-        if hasattr(self.config, "homing_strategy"):
-            value = getattr(self.config, "homing_strategy")
-            return getattr(value, "value", value)
-        return "standard"
 
     def _extract_status(self) -> str:
         """Extract the GRBL state word from the last raw status string."""

--- a/src/gantry/gantry_config.py
+++ b/src/gantry/gantry_config.py
@@ -7,12 +7,6 @@ from enum import Enum
 from typing import Any, Dict, Optional
 
 
-class HomingStrategy(str, Enum):
-    """Supported CNC homing strategies."""
-
-    STANDARD = "standard"
-
-
 class YAxisMotion(str, Enum):
     """Whether Y-axis motion moves the head or the bed (base plate)."""
 
@@ -66,7 +60,6 @@ class GantryConfig:
 
     serial_port: str
     gantry_type: GantryType
-    homing_strategy: HomingStrategy
     factory_z_travel_mm: float
     working_volume: WorkingVolume
     y_axis_motion: YAxisMotion = YAxisMotion.HEAD

--- a/src/gantry/loader.py
+++ b/src/gantry/loader.py
@@ -11,7 +11,6 @@ from .errors import GantryLoaderError
 from .gantry_config import (
     GantryConfig,
     GantryType,
-    HomingStrategy,
     WorkingVolume,
     YAxisMotion,
 )
@@ -86,7 +85,6 @@ def load_gantry_from_yaml(path: str | Path) -> GantryConfig:
     return GantryConfig(
         serial_port=schema.serial_port,
         gantry_type=GantryType(schema.gantry_type),
-        homing_strategy=HomingStrategy(schema.cnc.homing_strategy),
         factory_z_travel_mm=schema.cnc.factory_z_travel_mm,
         calibration_block_height_mm=schema.cnc.calibration_block_height_mm,
         safe_z=schema.safe_z,

--- a/src/gantry/yaml_schema.py
+++ b/src/gantry/yaml_schema.py
@@ -40,7 +40,6 @@ class CncYaml(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    homing_strategy: Literal["standard"]
     factory_z_travel_mm: float
     calibration_block_height_mm: Optional[float] = None
     y_axis_motion: Literal["head", "bed"] = "head"

--- a/src/protocol_engine/setup_validator.py
+++ b/src/protocol_engine/setup_validator.py
@@ -127,7 +127,6 @@ def run_setup_validation(
         f"  Working volume: X[{vol.x_min}, {vol.x_max}]  "
         f"Y[{vol.y_min}, {vol.y_max}]  Z[{vol.z_min}, {vol.z_max}]"
     )
-    out(f"  Homing strategy: {gantry_config.homing_strategy}")
     out()
 
     out("[2/4] Loading deck config...")

--- a/tests/deck/test_holder_labware.py
+++ b/tests/deck/test_holder_labware.py
@@ -16,7 +16,7 @@ from deck import (
     WellPlateHolder,
 )
 from deck.loader import load_deck_from_yaml
-from gantry.gantry_config import GantryConfig, GantryType, HomingStrategy, WorkingVolume
+from gantry.gantry_config import GantryConfig, GantryType, WorkingVolume
 from validation.bounds import validate_deck_positions
 
 
@@ -24,7 +24,6 @@ def _make_gantry() -> GantryConfig:
     return GantryConfig(
         serial_port="/dev/ttyUSB0",
         gantry_type=GantryType.CUB_XL,
-        homing_strategy=HomingStrategy.STANDARD,
         factory_z_travel_mm=90.0,
         working_volume=WorkingVolume(
             x_min=0.0,

--- a/tests/fixtures/configs/gantry/mock_asmi.yaml
+++ b/tests/fixtures/configs/gantry/mock_asmi.yaml
@@ -1,7 +1,6 @@
 serial_port: /dev/ttyUSB0
 gantry_type: cub_xl
 cnc:
-  homing_strategy: standard
   factory_z_travel_mm: 100.0
   y_axis_motion: head
   safe_z: 85.0

--- a/tests/fixtures/configs/gantry/mock_filmetrics.yaml
+++ b/tests/fixtures/configs/gantry/mock_filmetrics.yaml
@@ -1,7 +1,6 @@
 serial_port: /dev/ttyUSB0
 gantry_type: cub
 cnc:
-  homing_strategy: standard
   factory_z_travel_mm: 90.0
   y_axis_motion: head
   safe_z: 80.0

--- a/tests/fixtures/configs/gantry/mock_panda.yaml
+++ b/tests/fixtures/configs/gantry/mock_panda.yaml
@@ -1,7 +1,6 @@
 serial_port: /dev/ttyUSB0
 gantry_type: cub_xl
 cnc:
-  homing_strategy: standard
   factory_z_travel_mm: 100.0
   y_axis_motion: head
   safe_z: 85.0

--- a/tests/fixtures/configs/gantry/mock_sharc.yaml
+++ b/tests/fixtures/configs/gantry/mock_sharc.yaml
@@ -1,7 +1,6 @@
 serial_port: /dev/ttyUSB0
 gantry_type: cub
 cnc:
-  homing_strategy: standard
   factory_z_travel_mm: 101.5
   y_axis_motion: head
   safe_z: 101.5

--- a/tests/fixtures/configs/gantry/mock_sterling.yaml
+++ b/tests/fixtures/configs/gantry/mock_sterling.yaml
@@ -1,7 +1,6 @@
 serial_port: /dev/ttyUSB0
 gantry_type: cub_xl
 cnc:
-  homing_strategy: standard
   factory_z_travel_mm: 129.0
   y_axis_motion: head
   safe_z: 85.0

--- a/tests/gantry/test_gantry.py
+++ b/tests/gantry/test_gantry.py
@@ -157,12 +157,6 @@ class TestGantry(unittest.TestCase):
         mock_mill.home.assert_called_once_with()
 
     @patch("gantry.gantry.Mill")
-    def test_home_raises_on_unknown_strategy(self, mock_mill_cls):
-        gantry = Gantry(config={"cnc": {"homing_strategy": "nonexistent"}})
-        with self.assertRaises(ValueError):
-            gantry.home()
-
-    @patch("gantry.gantry.Mill")
     def test_prepare_for_protocol_run_unlocks_alarm_and_restores_state(
         self, mock_mill_cls
     ):

--- a/tests/gantry/test_gantry_config.py
+++ b/tests/gantry/test_gantry_config.py
@@ -7,7 +7,6 @@ import pytest
 from gantry.gantry_config import (
     GantryConfig,
     GantryType,
-    HomingStrategy,
     WorkingVolume,
 )
 
@@ -110,34 +109,20 @@ class TestGantryConfig:
         config = GantryConfig(
             serial_port="/dev/ttyUSB0",
             gantry_type=GantryType.CUB_XL,
-            homing_strategy=HomingStrategy.STANDARD,
             factory_z_travel_mm=90.0,
             working_volume=vol,
             safe_z=75.0,
         )
         assert config.serial_port == "/dev/ttyUSB0"
         assert config.gantry_type == GantryType.CUB_XL
-        assert config.homing_strategy == HomingStrategy.STANDARD
         assert config.factory_z_travel_mm == 90.0
         assert config.working_volume is vol
         assert config.safe_z == 75.0
-
-    def test_homing_strategy_is_enum(self):
-        config = GantryConfig(
-            serial_port="/dev/ttyUSB0",
-            gantry_type=GantryType.CUB_XL,
-            homing_strategy=HomingStrategy.STANDARD,
-            factory_z_travel_mm=90.0,
-            working_volume=_make_volume(),
-        )
-        assert isinstance(config.homing_strategy, HomingStrategy)
-        assert config.homing_strategy.value == "standard"
 
     def test_gantry_type_string_is_normalized_to_enum(self):
         config = GantryConfig(
             serial_port="/dev/ttyUSB0",
             gantry_type="cub_xl",
-            homing_strategy=HomingStrategy.STANDARD,
             factory_z_travel_mm=90.0,
             working_volume=_make_volume(),
         )
@@ -148,7 +133,6 @@ class TestGantryConfig:
             GantryConfig(
                 serial_port="/dev/ttyUSB0",
                 gantry_type="other_machine",
-                homing_strategy=HomingStrategy.STANDARD,
                 factory_z_travel_mm=90.0,
                 working_volume=_make_volume(),
             )
@@ -157,7 +141,6 @@ class TestGantryConfig:
         config = GantryConfig(
             serial_port="/dev/ttyUSB0",
             gantry_type=GantryType.CUB_XL,
-            homing_strategy=HomingStrategy.STANDARD,
             factory_z_travel_mm=90.0,
             working_volume=_make_volume(),
         )
@@ -172,7 +155,6 @@ class TestGantryConfig:
             GantryConfig(
                 serial_port="/dev/ttyUSB0",
                 gantry_type=GantryType.CUB_XL,
-                homing_strategy=HomingStrategy.STANDARD,
                 factory_z_travel_mm=-10.0,
                 working_volume=_make_volume(),
             )
@@ -182,7 +164,6 @@ class TestGantryConfig:
             GantryConfig(
                 serial_port="/dev/ttyUSB0",
                 gantry_type=GantryType.CUB_XL,
-                homing_strategy=HomingStrategy.STANDARD,
                 factory_z_travel_mm=0.0,
                 working_volume=_make_volume(),
             )
@@ -192,7 +173,6 @@ class TestGantryConfig:
             GantryConfig(
                 serial_port="/dev/ttyUSB0",
                 gantry_type=GantryType.CUB_XL,
-                homing_strategy=HomingStrategy.STANDARD,
                 factory_z_travel_mm=90.0,
                 working_volume=_make_volume(z_min=0.0, z_max=80.0),
                 safe_z=85.0,

--- a/tests/gantry/test_gantry_translation.py
+++ b/tests/gantry/test_gantry_translation.py
@@ -10,7 +10,7 @@ from gantry.gantry import Gantry
 
 def _config() -> dict:
     return {
-        "cnc": {"homing_strategy": "standard", "factory_z_travel_mm": 90.0},
+        "cnc": {"factory_z_travel_mm": 90.0},
         "working_volume": {
             "x_min": 0.0,
             "x_max": 300.0,

--- a/tests/gantry/test_instrument_loader.py
+++ b/tests/gantry/test_instrument_loader.py
@@ -41,7 +41,6 @@ def _gantry_yaml(
         "serial_port: /dev/ttyUSB0",
         "gantry_type: cub_xl",
         "cnc:",
-        "  homing_strategy: standard",
         "  factory_z_travel_mm: 90.0",
     ]
     if safe_z:
@@ -144,7 +143,6 @@ class TestLoadInstrumentedGantryFromConfig:
             serial_port: /dev/ttyUSB0
             gantry_type: cub_xl
             cnc:
-              homing_strategy: standard
               factory_z_travel_mm: 90.0
             working_volume:
               x_min: 0.0

--- a/tests/gantry/test_loader.py
+++ b/tests/gantry/test_loader.py
@@ -16,7 +16,6 @@ VALID_GANTRY_YAML = """\
 serial_port: /dev/cu.usbserial-2130
 gantry_type: cub_xl
 cnc:
-  homing_strategy: standard
   factory_z_travel_mm: 90.0
   safe_z: 75.0
 working_volume:
@@ -81,14 +80,6 @@ class TestLoadGantryFromYaml:
         finally:
             os.unlink(path)
 
-    def test_loaded_gantry_has_homing_strategy(self):
-        path = _write_temp_yaml(VALID_GANTRY_YAML)
-        try:
-            config = load_gantry_from_yaml(path)
-            assert config.homing_strategy == "standard"
-        finally:
-            os.unlink(path)
-
     def test_loaded_gantry_has_instruments_and_grbl_settings(self):
         path = _write_temp_yaml(GANTRY_WITH_INSTRUMENTS_YAML)
         try:
@@ -135,7 +126,6 @@ machine_structures:
 serial_port: /dev/ttyUSB0
 gantry_type: cub_xl
 cnc:
-  homing_strategy: standard
   factory_z_travel_mm: 90.0
 """
         path = _write_temp_yaml(yaml_content)
@@ -150,7 +140,6 @@ cnc:
 serial_port: /dev/ttyUSB0
 gantry_type: cub_xl
 cnc:
-  homing_strategy: standard
   factory_z_travel_mm: 90.0
 working_volume:
   x_min: 300.0
@@ -199,7 +188,6 @@ class TestLoadGantryFromYamlSafe:
         yaml_content = """\
 serial_port: /dev/ttyUSB0
 cnc:
-  homing_strategy: standard
   factory_z_travel_mm: 90.0
 """
         path = _write_temp_yaml(yaml_content)
@@ -217,7 +205,6 @@ cnc:
         yaml_content = """\
 serial_port: /dev/ttyUSB0
 cnc:
-  homing_strategy: standard
   factory_z_travel_mm: 90.0
 """
         path = _write_temp_yaml(yaml_content)

--- a/tests/gantry/test_origin.py
+++ b/tests/gantry/test_origin.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from gantry.gantry_config import GantryConfig, GantryType, HomingStrategy, WorkingVolume
+from gantry.gantry_config import GantryConfig, GantryType, WorkingVolume
 from gantry.origin import (
     DeckOriginCalibrationPlan,
     build_deck_origin_calibration_plan,
@@ -26,7 +26,6 @@ def _deck_origin_config(
     return GantryConfig(
         serial_port="/dev/null",
         gantry_type=GantryType.CUB_XL,
-        homing_strategy=HomingStrategy.STANDARD,
         factory_z_travel_mm=z_max,
         working_volume=WorkingVolume(
             x_min=x_min,

--- a/tests/gantry/test_yaml_schema.py
+++ b/tests/gantry/test_yaml_schema.py
@@ -12,7 +12,7 @@ def _valid_gantry_dict() -> dict:
     return {
         "serial_port": "/dev/cu.usbserial-2130",
         "gantry_type": "cub_xl",
-        "cnc": {"homing_strategy": "standard", "factory_z_travel_mm": 90.0},
+        "cnc": {"factory_z_travel_mm": 90.0},
         "working_volume": {
             "x_min": 0.0,
             "x_max": 300.0,
@@ -32,7 +32,6 @@ class TestGantryYamlSchema:
 
         assert schema.serial_port == "/dev/cu.usbserial-2130"
         assert schema.gantry_type == "cub_xl"
-        assert schema.cnc.homing_strategy == "standard"
         assert schema.cnc.factory_z_travel_mm == 90.0
         assert schema.working_volume.x_min == 0.0
         assert schema.working_volume.x_max == 300.0
@@ -41,14 +40,9 @@ class TestGantryYamlSchema:
         assert schema.working_volume.z_min == 0.0
         assert schema.working_volume.z_max == 80.0
 
-    def test_only_standard_homing_strategy_accepted(self):
+    def test_homing_strategy_is_rejected(self):
         data = _valid_gantry_dict()
-        schema = GantryYamlSchema.model_validate(data)
-        assert schema.cnc.homing_strategy == "standard"
-
-    def test_invalid_homing_strategy_rejected(self):
-        data = _valid_gantry_dict()
-        data["cnc"]["homing_strategy"] = "unknown_strategy"
+        data["cnc"]["homing_strategy"] = "standard"
         with pytest.raises(ValidationError):
             GantryYamlSchema.model_validate(data)
 

--- a/tests/protocol_engine/test_home_command.py
+++ b/tests/protocol_engine/test_home_command.py
@@ -8,7 +8,6 @@ from unittest.mock import MagicMock
 from gantry.gantry_config import (
     GantryConfig,
     GantryType,
-    HomingStrategy,
     WorkingVolume,
 )
 from protocol_engine.commands.home import home
@@ -27,7 +26,6 @@ def test_home_preserves_calibrated_wpos_for_deck_origin_config():
     config = GantryConfig(
         serial_port="/dev/ttyUSB0",
         gantry_type=GantryType.CUB_XL,
-        homing_strategy=HomingStrategy.STANDARD,
         factory_z_travel_mm=100.0,
         working_volume=WorkingVolume(
             x_min=0.0,
@@ -53,7 +51,6 @@ def test_home_preserves_calibrated_wpos_for_one_instrument_nonzero_z_min():
     config = GantryConfig(
         serial_port="/dev/ttyUSB0",
         gantry_type=GantryType.CUB_XL,
-        homing_strategy=HomingStrategy.STANDARD,
         factory_z_travel_mm=105.0,
         working_volume=WorkingVolume(
             x_min=0.0,
@@ -77,7 +74,6 @@ def test_home_preserves_calibrated_wpos_for_negative_space_config():
     config = GantryConfig(
         serial_port="/dev/ttyUSB0",
         gantry_type=GantryType.CUB_XL,
-        homing_strategy=HomingStrategy.STANDARD,
         factory_z_travel_mm=100.0,
         working_volume=WorkingVolume(
             x_min=-400.0,
@@ -101,7 +97,6 @@ def test_home_preserves_calibrated_wpos_for_zero_minimum_config():
     config = GantryConfig(
         serial_port="/dev/ttyUSB0",
         gantry_type=GantryType.CUB_XL,
-        homing_strategy=HomingStrategy.STANDARD,
         factory_z_travel_mm=100.0,
         working_volume=WorkingVolume(
             x_min=0.0,

--- a/tests/protocol_engine/test_mock_rail_guard_configs.py
+++ b/tests/protocol_engine/test_mock_rail_guard_configs.py
@@ -22,7 +22,6 @@ def test_validate_setup_home_over_rail_then_low_travel_fails(tmp_path):
             gantry_type: cub_xl
 
             cnc:
-              homing_strategy: standard
               factory_z_travel_mm: 130.0
               y_axis_motion: head
               safe_z: 110.0

--- a/tests/protocol_engine/test_setup_validator.py
+++ b/tests/protocol_engine/test_setup_validator.py
@@ -15,7 +15,6 @@ GANTRY_YAML = """\
 serial_port: /dev/ttyUSB0
 gantry_type: cub_xl
 cnc:
-  homing_strategy: standard
   factory_z_travel_mm: 90.0
 working_volume:
   x_min: 0.0

--- a/tests/setup/test_calibrate_deck_origin.py
+++ b/tests/setup/test_calibrate_deck_origin.py
@@ -26,7 +26,6 @@ def _write_gantry(path: Path, *, x_min: float = 0.0) -> Path:
 serial_port: /dev/ttyUSB0
 gantry_type: cub_xl
 cnc:
-  homing_strategy: standard
   factory_z_travel_mm: 100.0
   y_axis_motion: head
   safe_z: 85.0
@@ -466,7 +465,6 @@ def test_run_calibration_prints_full_gantry_yaml_with_grbl_settings(tmp_path):
 serial_port: /dev/ttyUSB0
 gantry_type: cub_xl
 cnc:
-  homing_strategy: standard
   factory_z_travel_mm: 100.0
   y_axis_motion: head
   safe_z: 85.0
@@ -853,7 +851,7 @@ def test_factory_z_travel_mm_raises_if_cnc_key_missing():
 
 def test_factory_z_travel_mm_raises_if_factory_z_travel_mm_key_missing():
     with pytest.raises(ValueError, match="cnc.factory_z_travel_mm"):
-        _factory_z_travel_mm({"cnc": {"homing_strategy": "standard"}})
+        _factory_z_travel_mm({"cnc": {}})
 
 
 def test_factory_z_travel_mm_raises_if_cnc_not_a_dict():
@@ -917,7 +915,6 @@ def _write_gantry_small_z(path):
 serial_port: /dev/ttyUSB0
 gantry_type: cub_xl
 cnc:
-  homing_strategy: standard
   factory_z_travel_mm: 15.0
   y_axis_motion: head
   safe_z: 12.0

--- a/tests/setup/test_calibrate_gantry.py
+++ b/tests/setup/test_calibrate_gantry.py
@@ -14,7 +14,6 @@ def _write_gantry(path: Path, instruments_yaml: str) -> Path:
         f"""\
 serial_port: /dev/ttyUSB0
 cnc:
-  homing_strategy: standard
   factory_z_travel_mm: 100.0
   y_axis_motion: head
 working_volume:

--- a/tests/setup/test_calibrate_multi_instrument_gantry.py
+++ b/tests/setup/test_calibrate_multi_instrument_gantry.py
@@ -22,7 +22,6 @@ def _write_multi_gantry(path: Path) -> Path:
 serial_port: /dev/ttyUSB0
 gantry_type: cub_xl
 cnc:
-  homing_strategy: standard
   factory_z_travel_mm: 100.0
   calibration_block_height_mm: 12.5
   y_axis_motion: head
@@ -563,7 +562,6 @@ def test_multi_instrument_calibration_raises_if_cnc_factory_z_travel_mm_missing(
 serial_port: /dev/ttyUSB0
 gantry_type: cub_xl
 cnc:
-  homing_strategy: standard
   y_axis_motion: head
 working_volume:
   x_min: 0.0

--- a/tests/setup/test_integration.py
+++ b/tests/setup/test_integration.py
@@ -34,7 +34,6 @@ GANTRY_YAML = """\
 serial_port: /dev/ttyUSB0
 gantry_type: cub_xl
 cnc:
-  homing_strategy: standard
   factory_z_travel_mm: 90.0
   safe_z: 70.0
 working_volume:
@@ -224,7 +223,6 @@ protocol:
 serial_port: /dev/ttyUSB0
 gantry_type: cub_xl
 cnc:
-  homing_strategy: standard
   factory_z_travel_mm: 90.0
 working_volume:
   x_min: 0.0

--- a/tests/setup/test_protocol_setup.py
+++ b/tests/setup/test_protocol_setup.py
@@ -38,7 +38,6 @@ GANTRY_YAML = """\
 serial_port: /dev/ttyUSB0
 gantry_type: cub_xl
 cnc:
-  homing_strategy: standard
   factory_z_travel_mm: 90.0
 working_volume:
   x_min: 0.0

--- a/tests/validation/test_bounds_validation.py
+++ b/tests/validation/test_bounds_validation.py
@@ -11,7 +11,7 @@ from deck.labware.vial import Vial
 from deck.labware.well_plate import WellPlate
 from deck.labware.well_plate_holder import WellPlateHolder
 from instruments.base_instrument import BaseInstrument
-from gantry.gantry_config import GantryConfig, GantryType, HomingStrategy, WorkingVolume
+from gantry.gantry_config import GantryConfig, GantryType, WorkingVolume
 from protocol_engine.protocol import Protocol, ProtocolStep
 from validation.bounds import (
     collect_protocol_motion_targets,
@@ -37,7 +37,6 @@ def _make_gantry(
     return GantryConfig(
         serial_port="/dev/ttyUSB0",
         gantry_type=GantryType.CUB_XL,
-        homing_strategy=HomingStrategy.STANDARD,
         factory_z_travel_mm=factory_z_travel_mm,
         working_volume=WorkingVolume(
             x_min=x_min, x_max=x_max,

--- a/tests/validation/test_machine_structures.py
+++ b/tests/validation/test_machine_structures.py
@@ -11,7 +11,6 @@ from deck.labware.well_plate import WellPlate
 from gantry.gantry_config import (
     GantryConfig,
     GantryType,
-    HomingStrategy,
     WorkingVolume,
 )
 from protocol_engine.protocol import Protocol, ProtocolStep
@@ -28,7 +27,6 @@ def _gantry(
     return GantryConfig(
         serial_port="/dev/ttyUSB0",
         gantry_type=gantry_type,
-        homing_strategy=HomingStrategy.STANDARD,
         factory_z_travel_mm=z_max,
         working_volume=WorkingVolume(
             x_min=0.0,

--- a/tests/validation/test_pipette_tip_state.py
+++ b/tests/validation/test_pipette_tip_state.py
@@ -15,7 +15,6 @@ from deck.labware.well_plate import WellPlate
 from gantry.gantry_config import (
     GantryConfig,
     GantryType,
-    HomingStrategy,
     WorkingVolume,
 )
 from protocol_engine.protocol import Protocol, ProtocolStep
@@ -36,7 +35,6 @@ def _gantry(
     return GantryConfig(
         serial_port="/dev/ttyUSB0",
         gantry_type=GantryType.CUB_XL,
-        homing_strategy=HomingStrategy.STANDARD,
         factory_z_travel_mm=z_max,
         working_volume=WorkingVolume(
             x_min=0.0,

--- a/tests/validation/test_protocol_semantics.py
+++ b/tests/validation/test_protocol_semantics.py
@@ -12,7 +12,7 @@ from deck.deck import Deck
 from deck.labware.labware import Coordinate3D
 from deck.labware.well_plate import WellPlate
 from deck.loader import load_deck_from_yaml
-from gantry.gantry_config import GantryConfig, GantryType, HomingStrategy, WorkingVolume
+from gantry.gantry_config import GantryConfig, GantryType, WorkingVolume
 from protocol_engine.protocol import Protocol, ProtocolStep
 from validation.protocol_semantics import validate_protocol_semantics
 
@@ -69,7 +69,6 @@ def _gantry_config(
     return GantryConfig(
         serial_port="/dev/null",
         gantry_type=GantryType.CUB_XL,
-        homing_strategy=HomingStrategy.STANDARD,
         factory_z_travel_mm=z_max,
         working_volume=WorkingVolume(
             x_min=0.0, x_max=x_max,

--- a/tests/validation/test_safe_z.py
+++ b/tests/validation/test_safe_z.py
@@ -14,7 +14,7 @@ from gantry.instrument_mount import InstrumentedGantry
 from deck.deck import Deck
 from deck.labware.labware import Coordinate3D
 from deck.labware.well_plate import WellPlate
-from gantry.gantry_config import GantryConfig, GantryType, HomingStrategy, WorkingVolume
+from gantry.gantry_config import GantryConfig, GantryType, WorkingVolume
 from protocol_engine.protocol import Protocol, ProtocolStep
 from validation.protocol_semantics import validate_protocol_semantics
 
@@ -23,7 +23,6 @@ def _gantry(safe_z: float = 85.0) -> GantryConfig:
     return GantryConfig(
         serial_port="/dev/ttyUSB0",
         gantry_type=GantryType.CUB_XL,
-        homing_strategy=HomingStrategy.STANDARD,
         factory_z_travel_mm=100.0,
         working_volume=WorkingVolume(
             x_min=0.0, x_max=400.0,
@@ -102,7 +101,6 @@ def test_scan_passes_when_safe_z_unconfigured():
     gantry = GantryConfig(
         serial_port="/dev/ttyUSB0",
         gantry_type=GantryType.CUB_XL,
-        homing_strategy=HomingStrategy.STANDARD,
         factory_z_travel_mm=100.0,
         working_volume=WorkingVolume(
             x_min=0.0, x_max=400.0,


### PR DESCRIPTION
## Summary
- remove `cnc.homing_strategy` from gantry YAML configs, fixtures, docs, and schema
- remove the `HomingStrategy` enum / `GantryConfig.homing_strategy` field
- keep gantry homing behavior on the standard GRBL `$H` command and reject `homing_strategy` as an unknown CNC key

Closes #182.

## Verification
- `/tmp/cubos-issue182-venv/bin/pytest tests/gantry/test_yaml_schema.py tests/gantry/test_loader.py tests/gantry/test_gantry_config.py tests/gantry/test_gantry.py tests/protocol_engine/test_home_command.py -q`
  - `139 passed, 6 subtests passed in 0.83s`
- `/tmp/cubos-issue182-venv/bin/pytest -q`
  - `1255 passed, 17 skipped, 10 subtests passed in 7.54s`
- `git diff --check`
  - passed
